### PR TITLE
Fix EXTRA calls and use-after-free bug with tokens (#73)

### DIFF
--- a/data/cexpr.gram
+++ b/data/cexpr.gram
@@ -1,15 +1,15 @@
 start[mod_ty]: a=stmt* $ { Module(a, NULL, p->arena) }
 stmt[stmt_ty]: a=expr_stmt { a }
-expr_stmt[stmt_ty]: a=expr NEWLINE { _Py_Expr(a, EXTRA(a, a)) }
-expr[expr_ty]: ( l=expr '+' r=term { _Py_BinOp(l, Add, r, EXTRA(l, r)) }
-               | l=expr '-' r=term { _Py_BinOp(l, Sub, r, EXTRA(l, r)) }
-               | t=term { t }
-               )
-term[expr_ty]: ( l=term '*' r=factor { _Py_BinOp(l, Mult, r, EXTRA(l, r)) }
-               | l=term '/' r=factor { _Py_BinOp(l, Div, r, EXTRA(l, r)) }
+expr_stmt[stmt_ty]: a=expression NEWLINE { _Py_Expr(a, EXTRA_EXPR(a, a)) }
+expression[expr_ty]: ( l=expression '+' r=term { _Py_BinOp(l, Add, r, EXTRA_EXPR(l, r)) }
+                     | l=expression '-' r=term { _Py_BinOp(l, Sub, r, EXTRA_EXPR(l, r)) }
+                     | t=term { t }
+                     )
+term[expr_ty]: ( l=term '*' r=factor { _Py_BinOp(l, Mult, r, EXTRA_EXPR(l, r)) }
+               | l=term '/' r=factor { _Py_BinOp(l, Div, r, EXTRA_EXPR(l, r)) }
                | f=factor { f }
                )
-factor[expr_ty]: ('(' e=expr ')' { e }
+factor[expr_ty]: ('(' e=expression ')' { e }
                  | a=atom { a }
                  )
 atom[expr_ty]: ( n=NAME { n }

--- a/data/cprog.gram
+++ b/data/cprog.gram
@@ -2,12 +2,12 @@ start[mod_ty]: a=stmt* ENDMARKER { Module(a, NULL, p->arena) }
 stmt[stmt_ty]: compound_stmt | simple_stmt
 compound_stmt[stmt_ty]: pass_stmt | if_stmt
 
-pass_stmt[stmt_ty]: a='pass' NEWLINE { _Py_Pass(EXTRA(a, a)) }
+pass_stmt[stmt_ty]: a='pass' NEWLINE { _Py_Pass(EXTRA(a, token_type, a, token_type)) }
 
 if_stmt[stmt_ty]:
-    | 'if' c=expr ':' t=suite e=[else_clause] { _Py_If(c, t, e, EXTRA(c, c)) }
+    | 'if' c=expression ':' t=suite e=[else_clause] { _Py_If(c, t, e, EXTRA_EXPR(c, c)) }
 else_clause[asdl_seq*]:
-    | 'elif' c=expr ':' t=suite e=[else_clause] { singleton_seq(p, _Py_If(c, t, e, EXTRA(c, c))) }
+    | 'elif' c=expression ':' t=suite e=[else_clause] { singleton_seq(p, _Py_If(c, t, e, EXTRA_EXPR(c, c))) }
     | 'else' ':' s=suite { s }
 
 suite[asdl_seq*]:
@@ -16,24 +16,24 @@ suite[asdl_seq*]:
 
 simple_stmt[stmt_ty]: a=expr_stmt NEWLINE { a }
 
-expr_stmt[stmt_ty]: a=expr { _Py_Expr(a, EXTRA(a, a)) }
+expr_stmt[stmt_ty]: a=expression { _Py_Expr(a, EXTRA_EXPR(a, a)) }
 
-expr[expr_ty]:
-    | l=expr '+' r=term { _Py_BinOp(l, Add, r, EXTRA(l, r)) }
-    | l=expr '-' r=term { _Py_BinOp(l, Sub, r, EXTRA(l, r)) }
+expression[expr_ty]:
+    | l=expression '+' r=term { _Py_BinOp(l, Add, r, EXTRA_EXPR(l, r)) }
+    | l=expression '-' r=term { _Py_BinOp(l, Sub, r, EXTRA_EXPR(l, r)) }
     | term
 term[expr_ty]:
-    | l=term '*' r=factor { _Py_BinOp(l, Mult, r, EXTRA(l, r)) }
-    | l=term '/' r=factor { _Py_BinOp(l, Div, r, EXTRA(l, r)) }
+    | l=term '*' r=factor { _Py_BinOp(l, Mult, r, EXTRA_EXPR(l, r)) }
+    | l=term '/' r=factor { _Py_BinOp(l, Div, r, EXTRA_EXPR(l, r)) }
     | factor
 factor[expr_ty]:
-    | l=primary '**' r=factor { _Py_BinOp(l, Pow, r, EXTRA(l, r)) }
+    | l=primary '**' r=factor { _Py_BinOp(l, Pow, r, EXTRA_EXPR(l, r)) }
     | primary
 primary[expr_ty]:
-    | f=primary '(' e=expr ')' { _Py_Call(f, singleton_seq(p, e), NULL, EXTRA(f, e)) }
+    | f=primary '(' e=expression ')' { _Py_Call(f, singleton_seq(p, e), NULL, EXTRA_EXPR(f, e)) }
     | atom
 atom[expr_ty]:
-    | '(' e=expr ')' { e }
+    | '(' e=expression ')' { e }
     | NAME
     | NUMBER
     | STRING

--- a/data/simpy.gram
+++ b/data/simpy.gram
@@ -20,7 +20,7 @@ small_stmt[stmt_ty]:
     | break_stmt
     | continue_stmt
     | assignment
-    | e=expressions { _Py_Expr(e, EXTRA(e, e)) }
+    | e=expressions { _Py_Expr(e, EXTRA_EXPR(e, e)) }
 compound_stmt: if_stmt | while_stmt | for_stmt | with_stmt | try_stmt | function_def | class_def
 
 # NOTE: yield_expression may start with 'yield'; yield_expr must start with 'yield'
@@ -36,44 +36,69 @@ assert_stmt: 'assert' expression [',' expression]
 
 del_stmt: 'del' targets  # TODO: exclude *target
 
-pass_stmt[stmt_ty]: a='pass' { _Py_Pass(EXTRA(a, a)) }
+pass_stmt[stmt_ty]: a='pass' { _Py_Pass(EXTRA(a, token_type, a, token_type)) }
 
-break_stmt: a='break' { _Py_Break(EXTRA(a, a)) }
+break_stmt: a='break' { _Py_Break(EXTRA(a, token_type, a, token_type)) }
 
-continue_stmt: a='continue' { _Py_Continue(EXTRA(a, a)) }
+continue_stmt: a='continue' { _Py_Continue(EXTRA(a, token_type, a, token_type)) }
 
 import_stmt: import_name | import_from
-import_name[stmt_ty]: a='import' b=dotted_as_names { _Py_Import(b, EXTRA(a, b)) }
+import_name[stmt_ty]: a='import' b=dotted_as_names {
+    _Py_Import(seq_map_to_alias(p, b), EXTRA(a, token_type, seq_get_tail(NULL, b), alias_type)) }
 # note below: the ('.' | '...') is necessary because '...' is tokenized as ELLIPSIS
 import_from[stmt_ty]:
     | a='from' b=('.' | '...')* !'import' c=dotted_name 'import' d=import_from_targets {
-        _Py_ImportFrom(((expr_ty) c)->v.Name.id, d, seq_count_dots(b), EXTRA(a, d)) }
-    | e='from' f=('.' | '...')+ 'import' g=import_from_targets { _Py_ImportFrom(NULL, g, seq_count_dots(f), EXTRA(e, g)) }
+        _Py_ImportFrom(c->v.Name.id,
+                       seq_map_to_alias(p, d),
+                       seq_count_dots(b),
+                       EXTRA(a, token_type, seq_get_tail(NULL, d), alias_type)) }
+    | e='from' f=('.' | '...')+ 'import' g=import_from_targets {
+        _Py_ImportFrom(NULL,
+                       seq_map_to_alias(p, g),
+                       seq_count_dots(f), 
+                       EXTRA(e, token_type, seq_get_tail(NULL, g), alias_type)) }
 import_from_targets[asdl_seq*]:
     | '(' a=import_from_as_names ')' { a }
     | import_from_as_names
-    | a='*' { singleton_seq(p, alias_for_star(p)) }
-import_from_as_names[asdl_seq*]: a=import_from_as_name b=(',' c=import_from_as_name { c })* [','] { seq_insert_in_front(p, a, b) }
-import_from_as_name[alias_ty]:
-    | a=NAME 'as' b=NAME { _Py_alias(((expr_ty) a)->v.Name.id, ((expr_ty) b)->v.Name.id, p->arena) }
-    | a=NAME { _Py_alias(((expr_ty) a)->v.Name.id, NULL, p->arena) }
-dotted_as_names[asdl_seq*]: a=dotted_as_name b=(',' c=dotted_as_name { c })* { seq_insert_in_front(p, a, b) }
-dotted_as_name[alias_ty]:
-    | a=dotted_name 'as' b=NAME { _Py_alias(((expr_ty) a)->v.Name.id, ((expr_ty) b)->v.Name.id, p->arena) }
-    | a=dotted_name { _Py_alias(((expr_ty) a)->v.Name.id, NULL, p->arena) }
+    | a='*' { singleton_seq(p, pegen_alias(alias_for_star(p),
+                                           EXTRA(a, token_type, a, token_type))) }
+import_from_as_names[asdl_seq*]:
+    | a=import_from_as_name b=(',' c=import_from_as_name { c })* [','] { seq_insert_in_front(p, a, b) }
+import_from_as_name[PegenAlias*]:
+    | a=NAME 'as' b=NAME {
+        pegen_alias(_Py_alias(((expr_ty) a)->v.Name.id, ((expr_ty) b)->v.Name.id, p->arena),
+                    EXTRA(a, expr_type, b, expr_type)) }
+    | a=NAME {
+        pegen_alias(_Py_alias(((expr_ty) a)->v.Name.id, NULL, p->arena),
+                    EXTRA(a, expr_type, a, expr_type)) }
+dotted_as_names[asdl_seq*]: 
+    | a=dotted_as_name b=(',' c=dotted_as_name { c })* { seq_insert_in_front(p, a, b) }
+dotted_as_name[PegenAlias*]:
+    | a=dotted_name 'as' b=NAME {
+        pegen_alias(_Py_alias(a->v.Name.id, ((expr_ty) b)->v.Name.id, p->arena),
+                    EXTRA(a, expr_type, b, expr_type)) }
+    | a=dotted_name {
+        pegen_alias(_Py_alias(a->v.Name.id, NULL, p->arena),
+                    EXTRA(a, expr_type, a, expr_type)) }
 dotted_name[expr_ty]:
     | a=dotted_name '.' b=NAME { join_names_with_dot(p, a, b) }
     | NAME
 
-if_stmt:
-    | 'if' a=full_expression ':' b=block c=else_block { _Py_If(a, b, c, EXTRA(a, c)) }
-    | 'if' a=full_expression ':' b=block c=elif_stmt { _Py_If(a, b, singleton_seq(p, c), EXTRA(a, c)) }
-    | 'if' a=full_expression ':' b=block { _Py_If(a, b, NULL, EXTRA(a, b)) }
-elif_stmt:
-    | 'elif' a=full_expression ':' b=block c=else_block { _Py_If(a, b, c, EXTRA(a, c)) }
-    | 'elif' a=full_expression ':' b=block c=elif_stmt { _Py_If(a, b, singleton_seq(p, c), EXTRA(a, c)) }
-    | 'elif' a=full_expression ':' b=block { _Py_If(a, b, NULL, EXTRA(a, b)) }
-else_block: 'else' ':' b=block { b }
+if_stmt[stmt_ty]:
+    | a='if' b=full_expression ':' c=block d=else_block {
+        _Py_If(b, c, d, EXTRA(a, token_type, seq_get_tail(NULL, d), stmt_type)) }
+    | a='if' b=full_expression ':' c=block e=elif_stmt {
+        _Py_If(b, c, singleton_seq(p, e), EXTRA(a, token_type, e, stmt_type)) }
+    | a='if' b=full_expression ':' c=block {
+        _Py_If(b, c, NULL, EXTRA(a, token_type, seq_get_tail(NULL, c), stmt_type)) }
+elif_stmt[stmt_ty]:
+    | 'elif' b=full_expression ':' c=block d=else_block {
+        _Py_If(b, c, d, EXTRA(b, expr_type, seq_get_tail(NULL, d), stmt_type)) }
+    | 'elif' b=full_expression ':' c=block e=elif_stmt {
+        _Py_If(b, c, singleton_seq(p, e), EXTRA(b, expr_type, e, stmt_type)) }
+    | 'elif' b=full_expression ':' c=block {
+        _Py_If(b, c, NULL, EXTRA(b, expr_type, seq_get_tail(NULL, c), stmt_type)) }
+else_block[asdl_seq*]: 'else' ':' b=block { b }
 
 while_stmt: 'while' full_expression ':' block [else_block]
 
@@ -115,7 +140,7 @@ decorators: ('@' factor NEWLINE)+
 
 class_def: [decorators] 'class' NAME ['(' [arguments] ')'] ':' block
 
-block: simple_stmt | NEWLINE INDENT a=statements DEDENT { a }
+block[asdl_seq*]: simple_stmt | NEWLINE INDENT a=statements DEDENT { a }
 
 star_full_expressions: (star_full_expression) (',' (star_full_expression))* [',']
 expressions: ('*' bitwise_or | expression) (',' ('*' bitwise_or | expression))* [',']

--- a/pegen/pegen.h
+++ b/pegen/pegen.h
@@ -14,17 +14,22 @@ typedef struct _memo {
 typedef struct {
     int type;
     PyObject *bytes;
-    int line, col, endline, endcol;
+    int lineno, col_offset, end_lineno, end_col_offset;
     Memo *memo;
 } Token;
 
 typedef struct {
     struct tok_state *tok;
-    Token *tokens;
+    Token **tokens;
     int mark;
     int fill, size;
     PyArena *arena;
 } Parser;
+
+typedef struct {
+    alias_ty alias;
+    int lineno, col_offset, end_lineno, end_col_offset;
+} PegenAlias;
 
 int insert_memo(Parser *p, int mark, int type, void *node);
 int update_memo(Parser *p, int mark, int type, void *node);
@@ -49,11 +54,12 @@ void *keyword_token(Parser *p, const char *val);
 
 void *CONSTRUCTOR(Parser *p, ...);
 
-#define LINE(arg) ((expr_ty)(arg))->lineno
-#define COL(arg) ((expr_ty)(arg))->col_offset
-#define ENDLINE(arg) ((expr_ty)(arg))->end_lineno
-#define ENDCOL(arg) ((expr_ty)(arg))->end_col_offset
-#define EXTRA(head, tail) LINE(head), COL(head), ENDLINE(tail), ENDCOL(tail), p->arena
+#define EXTRA_EXPR(head, tail) EXTRA(head, expr_type, tail, expr_type)
+#define EXTRA(head, head_type_func, tail, tail_type_func) head_type_func##_headline(head), \
+                                                          head_type_func##_headcol(head), \
+                                                          tail_type_func##_tailline(tail), \
+                                                          tail_type_func##_tailcol(tail), \
+                                                          p->arena
 
 PyObject *run_parser_from_file(const char *filename, void *(start_rule_func)(Parser *), int mode);
 PyObject *run_parser_from_string(const char *str, void *(start_rule_func)(Parser *), int mode);
@@ -63,3 +69,23 @@ asdl_seq *seq_flatten(Parser *, asdl_seq *);
 expr_ty join_names_with_dot(Parser *, expr_ty, expr_ty);
 int seq_count_dots(asdl_seq *);
 alias_ty alias_for_star(Parser *);
+void *seq_get_tail(void *, asdl_seq *);
+PegenAlias *pegen_alias(alias_ty, int, int, int, int, PyArena *);
+asdl_seq *seq_map_to_alias(Parser *, asdl_seq *);
+
+inline int expr_type_headline(expr_ty a) { return a->lineno; }
+inline int expr_type_headcol(expr_ty a) { return a->col_offset; }
+inline int expr_type_tailline(expr_ty a) { return a->end_lineno; }
+inline int expr_type_tailcol(expr_ty a) { return a->end_col_offset; }
+inline int stmt_type_headline(stmt_ty a) { return a->lineno; }
+inline int stmt_type_headcol(stmt_ty a) { return a->col_offset; }
+inline int stmt_type_tailline(stmt_ty a) { return a->end_lineno; }
+inline int stmt_type_tailcol(stmt_ty a) { return a->end_col_offset; }
+inline int token_type_headline(Token *a) { return a->lineno; }
+inline int token_type_headcol(Token *a) { return a->col_offset; }
+inline int token_type_tailline(Token *a) { return a->end_lineno; }
+inline int token_type_tailcol(Token *a) { return a->end_col_offset; }
+inline int alias_type_headline(PegenAlias *a) { return a->lineno; }
+inline int alias_type_headcol(PegenAlias *a) { return a->col_offset; }
+inline int alias_type_tailline(PegenAlias *a) { return a->end_lineno; }
+inline int alias_type_tailcol(PegenAlias *a) { return a->end_col_offset; }

--- a/test/test_data/if_elif.py
+++ b/test/test_data/if_elif.py
@@ -1,4 +1,4 @@
 if a:
     pass
-else:
+elif b:
     pass


### PR DESCRIPTION
* Create PegenAlias, a wrapper for alias_ty that contains line/col info
* Rename line/col to lineno/col_offset like in expr_ty
* Refactor Parser to hold an array of Token *'s instead of an array of Tokens
* Use token pasting to avoid type functions and just use macros for the different casts needed
* Make inline functions out of all the type macros

* Allow all python test files to be tested even in the case of a failure
* Stylistic refactorings to the Grammar
* Remove unnecessary casts in the Grammar