### PR TITLE
Implement dot operator (#76)

### DIFF
--- a/pegen/grammar.py
+++ b/pegen/grammar.py
@@ -72,6 +72,9 @@ class Rule:
     def is_loop(self) -> bool:
         return self.name.startswith("_loop")
 
+    def is_gather(self) -> bool:
+        return self.name.startswith("_tmp_sep")
+
     def __str__(self) -> str:
         if self.type is None:
             return f"{self.name}: {self.rhs}"
@@ -374,6 +377,21 @@ class Repeat1(Repeat):
 
     def __repr__(self) -> str:
         return f"Repeat1({self.node!r})"
+
+    def nullable_visit(self, rules: Dict[str, Rule]) -> bool:
+        return False
+
+
+class RepeatWithSeparator(Repeat):
+    def __init__(self, separator: Plain, node: Plain):
+        self.separator = separator
+        self.node = node
+
+    def __str__(self) -> str:
+        return f"{self.separator!s}.{self.node!s}"
+
+    def __repr__(self) -> str:
+        return f"RepeatWithSeparator({self.separator!r}, {self.node!r})"
 
     def nullable_visit(self, rules: Dict[str, Rule]) -> bool:
         return False

--- a/pegen/grammar_parser.py
+++ b/pegen/grammar_parser.py
@@ -28,6 +28,7 @@ from pegen.grammar import (
     PositiveLookahead,
     Repeat0,
     Repeat1,
+    RepeatWithSeparator,
     Rhs,
     Rule,
     RuleList,
@@ -446,7 +447,7 @@ class GeneratedParser(Parser):
 
     @memoize
     def item(self) -> Optional[Item]:
-        # item: '[' ~ alts ']' { Opt ( alts ) } | atom '?' { Opt ( atom ) } | atom '*' { Repeat0 ( atom ) } | atom '+' { Repeat1 ( atom ) } | atom { atom }
+        # item: '[' ~ alts ']' { Opt ( alts ) } | atom '?' { Opt ( atom ) } | atom '*' { Repeat0 ( atom ) } | atom '+' { Repeat1 ( atom ) } | sep=atom '.' node=atom '+' { RepeatWithSeparator ( sep , node ) } | atom { atom }
         mark = self.mark()
         cut = False
         if (
@@ -486,6 +487,19 @@ class GeneratedParser(Parser):
             (literal := self.expect('+'))
         ):
             return Repeat1 ( atom )
+        self.reset(mark)
+        if cut: return None
+        cut = False
+        if (
+            (sep := self.atom())
+            and
+            (literal := self.expect('.'))
+            and
+            (node := self.atom())
+            and
+            (literal_1 := self.expect('+'))
+        ):
+            return RepeatWithSeparator ( sep , node )
         self.reset(mark)
         if cut: return None
         cut = False

--- a/pegen/metagrammar.gram
+++ b/pegen/metagrammar.gram
@@ -19,6 +19,7 @@ from pegen.grammar import (
     PositiveLookahead,
     Repeat0,
     Repeat1,
+    RepeatWithSeparator,
     Rhs,
     Rule,
     RuleList,
@@ -90,6 +91,7 @@ item[Item]:
     |  atom '?' {Opt(atom)}
     |  atom '*' {Repeat0(atom)}
     |  atom '+' {Repeat1(atom)}
+    |  sep=atom '.' node=atom '+' {RepeatWithSeparator(sep, node)}
     |  atom {atom}
 
 atom[Plain]:

--- a/test/test_pegen.py
+++ b/test/test_pegen.py
@@ -47,6 +47,20 @@ def test_typed_rules():
     )
 
 
+def test_repeat_with_separator_rules():
+    grammar = """
+    start: ','.thing+ NEWLINE
+    thing: NUMBER
+    """
+    rules = parse_string(grammar, GrammarParser).rules
+    assert str(rules["start"]) == "start: ','.thing NEWLINE"
+    print(repr(rules["start"]))
+    assert repr(rules["start"]).startswith(
+        "Rule('start', None, Rhs([Alt([NamedItem(None, RepeatWithSeparator(StringLeaf(\"','\"), NameLeaf('thing'"
+    )
+    assert str(rules["thing"]) == "thing: NUMBER"
+
+
 def test_expr_grammar():
     grammar = """
     start: sum NEWLINE
@@ -229,6 +243,23 @@ def test_repeat_1_complex():
     ]
     with pytest.raises(SyntaxError):
         parse_string("1\n", parser_class)
+
+
+def test_repeat_with_sep_simple():
+    grammar = """
+    start: ','.thing+ NEWLINE
+    thing: NUMBER
+    """
+    parser_class = make_parser(grammar)
+    node = parse_string("1, 2, 3\n", parser_class)
+    assert node == [
+        [
+            [TokenInfo(NUMBER, string="1", start=(1, 0), end=(1, 1), line="1, 2, 3\n")],
+            [TokenInfo(NUMBER, string="2", start=(1, 3), end=(1, 4), line="1, 2, 3\n")],
+            [TokenInfo(NUMBER, string="3", start=(1, 6), end=(1, 7), line="1, 2, 3\n")],
+        ],
+        TokenInfo(NEWLINE, string="\n", start=(1, 7), end=(1, 8), line="1, 2, 3\n"),
+    ]
 
 
 def test_left_recursive():


### PR DESCRIPTION
Example:
```
expr_list: ','.expr+
```
is equivalent to
```
expr_list: expr (',' expr)*
```
For actions, the item is simply a list of `expr`s (the separators are not included).