### PR TITLE
Fully annotate test_pegen.py (#83)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 PYTHON ?= `/usr/bin/which python3.8`
 CPYTHON ?= "./cpython"
+MYPY ?= `/usr/bin/which mypy`
 
 GRAMMAR = data/cprog.gram
 TESTFILE = data/cprog.txt
@@ -57,7 +58,7 @@ simpy_cpython:
 		--exclude "*/lib2to3/tests/data/*"
 
 mypy: regen-metaparser
-	mypy  # For list of files, see mypy.ini
+	$(MYPY)  # For list of files, see mypy.ini
 
 black:
 	black pegen tatsu test scripts

--- a/pegen/__main__.py
+++ b/pegen/__main__.py
@@ -72,6 +72,7 @@ def main() -> None:
         if args.verbose:
             raise  # Show traceback
         traceback.print_exception(err.__class__, err, None)
+        sys.stderr.write("For full traceback, use -v\n")
         sys.exit(1)
 
     if not args.quiet:

--- a/pegen/grammar_parser.py
+++ b/pegen/grammar_parser.py
@@ -41,7 +41,7 @@ class GeneratedParser(Parser):
 
     @memoize
     def start(self) -> Optional[Grammar]:
-        # start: grammar $ { grammar }
+        # start: grammar $
         mark = self.mark()
         cut = False
         if (
@@ -56,7 +56,7 @@ class GeneratedParser(Parser):
 
     @memoize
     def grammar(self) -> Optional[Grammar]:
-        # grammar: metas rules { Grammar ( rules , metas ) } | rules { Grammar ( rules , [ ] ) }
+        # grammar: metas rules | rules
         mark = self.mark()
         cut = False
         if (
@@ -78,7 +78,7 @@ class GeneratedParser(Parser):
 
     @memoize
     def metas(self) -> Optional[MetaList]:
-        # metas: meta metas { [ meta ] + metas } | meta { [ meta ] }
+        # metas: meta metas | meta
         mark = self.mark()
         cut = False
         if (
@@ -100,7 +100,7 @@ class GeneratedParser(Parser):
 
     @memoize
     def meta(self) -> Optional[MetaTuple]:
-        # meta: "@" NAME NEWLINE { ( name . string , None ) } | "@" a=NAME b=NAME NEWLINE { ( a . string , b . string ) } | "@" NAME STRING NEWLINE { ( name . string , literal_eval ( string . string ) ) }
+        # meta: "@" NAME NEWLINE | "@" NAME NAME NEWLINE | "@" NAME STRING NEWLINE
         mark = self.mark()
         cut = False
         if (
@@ -143,7 +143,7 @@ class GeneratedParser(Parser):
 
     @memoize
     def rules(self) -> Optional[RuleList]:
-        # rules: rule rules { [ rule ] + rules } | rule { [ rule ] }
+        # rules: rule rules | rule
         mark = self.mark()
         cut = False
         if (
@@ -165,7 +165,7 @@ class GeneratedParser(Parser):
 
     @memoize
     def rule(self) -> Optional[Rule]:
-        # rule: rulename ":" alts NEWLINE INDENT more_alts DEDENT { Rule ( rulename [ 0 ] , rulename [ 1 ] , Rhs ( alts . alts + more_alts . alts ) ) } | rulename ":" NEWLINE INDENT more_alts DEDENT { Rule ( rulename [ 0 ] , rulename [ 1 ] , more_alts ) } | rulename ":" alts NEWLINE { Rule ( rulename [ 0 ] , rulename [ 1 ] , alts ) }
+        # rule: rulename ":" alts NEWLINE INDENT more_alts DEDENT | rulename ":" NEWLINE INDENT more_alts DEDENT | rulename ":" alts NEWLINE
         mark = self.mark()
         cut = False
         if (
@@ -220,7 +220,7 @@ class GeneratedParser(Parser):
 
     @memoize
     def rulename(self) -> Optional[RuleName]:
-        # rulename: NAME '[' type=NAME '*' ']' { ( name . string , type . string + "*" ) } | NAME '[' type=NAME ']' { ( name . string , type . string ) } | NAME { ( name . string , None ) }
+        # rulename: NAME '[' NAME '*' ']' | NAME '[' NAME ']' | NAME
         mark = self.mark()
         cut = False
         if (
@@ -261,7 +261,7 @@ class GeneratedParser(Parser):
 
     @memoize
     def alts(self) -> Optional[Rhs]:
-        # alts: alt "|" alts { Rhs ( [ alt ] + alts . alts ) } | alt { Rhs ( [ alt ] ) }
+        # alts: alt "|" alts | alt
         mark = self.mark()
         cut = False
         if (
@@ -285,7 +285,7 @@ class GeneratedParser(Parser):
 
     @memoize
     def more_alts(self) -> Optional[Rhs]:
-        # more_alts: "|" alts NEWLINE more_alts { Rhs ( alts . alts + more_alts . alts ) } | "|" alts NEWLINE { Rhs ( alts . alts ) }
+        # more_alts: "|" alts NEWLINE more_alts | "|" alts NEWLINE
         mark = self.mark()
         cut = False
         if (
@@ -315,7 +315,7 @@ class GeneratedParser(Parser):
 
     @memoize
     def alt(self) -> Optional[Alt]:
-        # alt: items '$' action { Alt ( items + [ NamedItem ( None , NameLeaf ( 'ENDMARKER' ) ) ] , action = action ) } | items '$' { Alt ( items + [ NamedItem ( None , NameLeaf ( 'ENDMARKER' ) ) ] , action = None ) } | items action { Alt ( items , action = action ) } | items { Alt ( items , action = None ) }
+        # alt: items '$' action | items '$' | items action | items
         mark = self.mark()
         cut = False
         if (
@@ -357,7 +357,7 @@ class GeneratedParser(Parser):
 
     @memoize
     def items(self) -> Optional[NamedItemList]:
-        # items: named_item items { [ named_item ] + items } | named_item { [ named_item ] }
+        # items: named_item items | named_item
         mark = self.mark()
         cut = False
         if (
@@ -379,7 +379,7 @@ class GeneratedParser(Parser):
 
     @memoize
     def named_item(self) -> Optional[NamedItem]:
-        # named_item: NAME '=' ~ item { NamedItem ( name . string , item ) } | item { NamedItem ( None , item ) } | it=lookahead { NamedItem ( None , it ) }
+        # named_item: NAME '=' ~ item | item | lookahead
         mark = self.mark()
         cut = False
         if (
@@ -412,7 +412,7 @@ class GeneratedParser(Parser):
 
     @memoize
     def lookahead(self) -> Optional[LookaheadOrCut]:
-        # lookahead: '&' ~ atom { PositiveLookahead ( atom ) } | '!' ~ atom { NegativeLookahead ( atom ) } | '~' { Cut ( ) }
+        # lookahead: '&' ~ atom | '!' ~ atom | '~'
         mark = self.mark()
         cut = False
         if (
@@ -447,7 +447,7 @@ class GeneratedParser(Parser):
 
     @memoize
     def item(self) -> Optional[Item]:
-        # item: '[' ~ alts ']' { Opt ( alts ) } | atom '?' { Opt ( atom ) } | atom '*' { Repeat0 ( atom ) } | atom '+' { Repeat1 ( atom ) } | sep=atom '.' node=atom '+' { Gather ( sep , node ) } | atom { atom }
+        # item: '[' ~ alts ']' | atom '?' | atom '*' | atom '+' | atom '.' atom '+' | atom
         mark = self.mark()
         cut = False
         if (
@@ -513,7 +513,7 @@ class GeneratedParser(Parser):
 
     @memoize
     def atom(self) -> Optional[Plain]:
-        # atom: '(' ~ alts ')' { Group ( alts ) } | NAME { NameLeaf ( name . string ) } | STRING { StringLeaf ( string . string ) }
+        # atom: '(' ~ alts ')' | NAME | STRING
         mark = self.mark()
         cut = False
         if (
@@ -546,7 +546,7 @@ class GeneratedParser(Parser):
 
     @memoize
     def action(self) -> Optional[str]:
-        # action: "{" ~ target_atoms "}" { target_atoms }
+        # action: "{" ~ target_atoms "}"
         mark = self.mark()
         cut = False
         if (
@@ -565,7 +565,7 @@ class GeneratedParser(Parser):
 
     @memoize
     def target_atoms(self) -> Optional[str]:
-        # target_atoms: target_atom target_atoms { target_atom + " " + target_atoms } | target_atom { target_atom }
+        # target_atoms: target_atom target_atoms | target_atom
         mark = self.mark()
         cut = False
         if (
@@ -587,7 +587,7 @@ class GeneratedParser(Parser):
 
     @memoize
     def target_atom(self) -> Optional[str]:
-        # target_atom: "{" ~ target_atoms "}" { "{" + target_atoms + "}" } | NAME { name . string } | NUMBER { number . string } | STRING { string . string } | !"}" OP { op . string }
+        # target_atom: "{" ~ target_atoms "}" | NAME | NUMBER | STRING | !"}" OP
         mark = self.mark()
         cut = False
         if (

--- a/pegen/testutil.py
+++ b/pegen/testutil.py
@@ -29,9 +29,9 @@ def generate_parser(grammar: Grammar) -> Type[Parser]:
     return ns["GeneratedParser"]
 
 
-def run_parser(file: IO[str], parser_class: Type[Parser], *, verbose: bool = False) -> Any:
+def run_parser(file: IO[bytes], parser_class: Type[Parser], *, verbose: bool = False) -> Any:
     # Run a parser on a file (stream).
-    tokenizer = Tokenizer(tokenize.generate_tokens(file.readline))
+    tokenizer = Tokenizer(tokenize.generate_tokens(file.readline))  # type: ignore # typeshed issue #3515
     parser = parser_class(tokenizer, verbose=verbose)
     result = parser.start()
     if result is None:
@@ -46,7 +46,7 @@ def parse_string(
     if dedent:
         source = textwrap.dedent(source)
     file = io.StringIO(source)
-    return run_parser(file, parser_class, verbose=verbose)
+    return run_parser(file, parser_class, verbose=verbose)  # type: ignore # typeshed issue #3515
 
 
 def make_parser(source: str) -> Type[Parser]:


### PR DESCRIPTION
There are two `# type: ignore` lines that need to be removed once we upgrade to mypy 0.760 (not out yet), see https://github.com/python/typeshed/issues/3515.

Fixes #57