### PR TITLE
Documentation about helper functions and grammar syntax (#93)

### DIFF
--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -1,0 +1,141 @@
+Syntax
+------
+
+The grammar consists of a sequence of rules of the form:
+```
+rule_name: expression
+```
+
+Optionally, a type can be included right after the rule name,
+which specifies the return type of the C or Python function
+corresponding to the rule:
+```
+rule_name[return_type]: expression
+```
+If the return type is omitted, then a `void *` is
+returned in C and an `Any` in Python.
+
+### Grammar Expressions
+
+##### `# comment`
+Python-style comments.
+
+##### `e1 e2`
+Match e1, then match e2.
+```
+rule_name: first_rule second_rule
+```
+
+##### `e1 | e2`
+Match e1 or e2.
+
+The first alternative can also appear on the line after the rule
+name for formatting purposes.  In that case, a | can also be used
+before the first alternative, like so:
+```
+rule_name[return_type]:
+    | first_alt
+    | second_alt
+```
+
+##### `( e )`
+Match e.
+```
+rule_name: (e)
+```
+
+A slightly more complex and useful example includes using the grouping
+operator together with the repeat operators:
+```
+rule_name: (e1 e2)*
+```
+
+##### `[ e ] or e?`
+Optinally match e.
+```
+rule_name: [e]
+```
+
+A more useful example includes defining that a trailing comma is optional:
+```
+rule_name: e (',' e)* [',']
+```
+
+##### `e*`
+Match zero or more occurences of e.
+```
+rule_name: (e1 e2)*
+```
+
+##### `e+`
+Match one or more occurences of e.
+```
+rule_name: (e1 e2)+
+```
+##### `s.e+`
+Match one or more occurences of e, separated by s. The generated parse tree
+does not include the separator. This is identical to `(e (s e)*)`.
+```
+rule_name: ','.e+
+```
+
+##### `&e`
+Succeed if e can be parsed, without consuming any input.
+
+##### `!e`
+Fail if e can be parsed, without consuming any input.
+
+An example taken from `data/simpy.gram` specifies that a primary
+consists of an atom, which is not followed by a `.` or a `(` or
+a `[`:
+```
+primary: atom !'.' !'(' !'['
+```
+
+##### `~e`
+Commit to the current alternative, even if it fails to parse.
+```
+rule_name: '(' ~ some_rule ')' | some_alt
+```
+In this example, if a left parenthesis is parsed, then the other
+alternative won't be considered, even if some_rule or ')' fail
+to be parsed.
+
+
+### Return Value
+
+Optionally, an alternative can be followed by a so-called action
+in curly-braces, which specifies the return value of the alternative:
+```
+rule_name[return_type]:
+    | first_alt1 first_alt2 { first_alt1 }
+    | second_alt1 second_alt2 { second_alt1 }
+```
+If the action is omitted and C code is being generated, then there
+are two different possibilities:
+1.  If there's a single name in the alternative, this gets returned.
+2.  If not, a dummy name object gets returned.
+
+If Python code is being generated, then a list with all the parsed
+expressions gets returned.
+
+
+### Variables in the Grammar
+
+A subexpression can be named by preceding it with an identifier and an `=` sign.
+The name can then be used in the action, like this:
+```
+rule_name[return_type]: '(' a=some_other_rule ')' { a }
+```
+
+Style
+-----
+
+This is not a hard limit, but lines longer than 110 characters should almost
+always be wrapped.  Most lines should be wrapped after the opening action
+curly brace, like:
+
+```
+really_long_rule[expr_ty]: some_arbitrary_rule {
+    _This_is_the_action }
+```

--- a/docs/helpers.md
+++ b/docs/helpers.md
@@ -1,0 +1,98 @@
+Helper Structs
+--------------
+
+The following are all types defined in `pegen/pegen.h`.
+
+##### Memo
+
+Linked list, optimized for quickly finding a given type.
+
+- type: int, either a token or a rule (rules start at 256)
+- node: NULL or pointer to AST node OR pointer to token object
+- mark: if node != NULL, index into Parser's array of tokens
+- next: NULL or pointer to next Memo structure
+
+##### Token
+
+These are in an array linked from Parser.
+
+- type: int, token type (needs only 8 bits)
+- bytes: bytes object
+- lineno, col_offset, end_lineno, end_col_offset: int
+- memo: Pointer to linked list Memo
+
+##### Parser
+
+The Parser needs to point to a PyArena, used for allocating AST nodes and
+other things.
+
+- tok: Pointer to tokenizer, CPython's struct tok_state
+- tokens: Pointer to array of Token pointers
+- mark: index into array of Tokens
+- fill: number of valid entries in array of Tokens
+- size: total number of entries in array of Tokens
+- arena: memory allocation arena (owns all AST, Token, Memo structures allocated)
+
+##### PegenAlias
+
+Needed because alias_ty does not hold line and column offset info.
+When a rule needs to return an alias_ty, it returns a PegenAlias*
+instead so that line and column info get propagated to the caller,
+which extracts this info together with the alias_ty.
+
+- alias: alias_ty
+- lineno, col_offset, end_lineno, end_col_offset: int
+
+##### CmpopExprPair
+
+This gets used by the rules that implement comparison, due to the
+structure of the Compare AST Object.
+
+- cmpop: cmpop_ty, The comparison operator
+- expr: expr_ty, The expression that gets compared
+
+
+Helper Functions
+----------------
+
+###### `asdl_seq *singleton_seq(Parser *p, void *a)`
+Creates a single-element `asdl_seq *` that contains `a`.
+
+###### `asdl_seq *seq_insert_in_front(Parser *p, void *a, asdl_seq *seq)`
+Creates a copy of `seq` and prepends `a` to it.
+
+###### `asdl_seq *seq_flatten(Parser *p, asdl_seq *seq)`
+Flattens an `asdl_seq *` of `asdl_seq *`s.
+
+###### `expr_ty join_names_with_dot(Parser *p, expr_ty first_name, expr_ty second_name)`
+Creates a new name of the form <first_name>.<second_name>.
+
+###### `int seq_count_dots(asdl_seq *seq)`
+Counts the total number of dots in `seq`s tokens.
+
+###### `alias_ty alias_for_star(Parser *p)`
+Creates an alias with `*` as the identifier name.
+
+###### `void *seq_get_tail(void *previous, asdl_seq *seq)`
+Returns the last element of `seq` or `previous` if `seq` is empty.
+
+###### `PegenAlias *pegen_alias(alias_ty alias, int lineno, int col_offset, int end_lineno, int end_col_offset, PyArena *arena)`
+Constructs a `PegenAlias`.
+
+###### `asdl_seq *extract_orig_aliases(Parser *p, asdl_seq *seq)`
+Extracts `alias_ty`s from an `asdl_seq *` of `PegenAlias *`s.
+
+###### `asdl_seq *map_names_to_ids(Parser *p, asdl_seq *seq)`
+Creates a new `asdl_seq *` with the identifiers of all the names in `seq`.
+
+###### `CmpopExprPair *cmpop_expr_pair(Parser *p, cmpop_ty cmpop, expr_ty expr)`
+Constructs a `CmpopExprPair`.
+
+###### `expr_ty Pegen_Compare(Parser *p, expr_ty expr, asdl_seq *pairs)`
+Wrapper for `_Py_Compare`, so that the call in the grammar stays concise.
+
+###### `expr_ty store_name(Parser *p, expr_ty load_name)`
+Accepts a load name and creates an identical store name.
+
+###### `asdl_seq *map_targets_to_del_names(Parser *p, asdl_seq *seq)`
+Creates an `asdl_seq *` where all the elements have been changed to have del as context.


### PR DESCRIPTION
* Add docstrings to C helper functions
* Add leading underscore to C helper functions only used from within pegen.c
* Document all the different grammar constructs
* Document all the C structs and helper functions