### PR TITLE
Refactor EXTRA macro and extract the line and col info out of band (#…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-python: 3.8
+python: 3.8-dev
 
 notifications:
   on_success: change

--- a/data/cprog.gram
+++ b/data/cprog.gram
@@ -2,12 +2,12 @@ start[mod_ty]: a=stmt* ENDMARKER { Module(a, NULL, p->arena) }
 stmt[stmt_ty]: compound_stmt | simple_stmt
 compound_stmt[stmt_ty]: pass_stmt | if_stmt
 
-pass_stmt[stmt_ty]: a='pass' NEWLINE { _Py_Pass(EXTRA(a, token_type, a, token_type)) }
+pass_stmt[stmt_ty]: a='pass' NEWLINE { _Py_Pass(EXTRA) }
 
 if_stmt[stmt_ty]:
-    | 'if' c=expression ':' t=suite e=[else_clause] { _Py_If(c, t, e, EXTRA_EXPR(c, c)) }
+    | 'if' c=expression ':' t=suite e=[else_clause] { _Py_If(c, t, e, EXTRA) }
 else_clause[asdl_seq*]:
-    | 'elif' c=expression ':' t=suite e=[else_clause] { singleton_seq(p, _Py_If(c, t, e, EXTRA_EXPR(c, c))) }
+    | 'elif' c=expression ':' t=suite e=[else_clause] { singleton_seq(p, _Py_If(c, t, e, EXTRA)) }
     | 'else' ':' s=suite { s }
 
 suite[asdl_seq*]:
@@ -16,21 +16,21 @@ suite[asdl_seq*]:
 
 simple_stmt[stmt_ty]: a=expr_stmt NEWLINE { a }
 
-expr_stmt[stmt_ty]: a=expression { _Py_Expr(a, EXTRA_EXPR(a, a)) }
+expr_stmt[stmt_ty]: a=expression { _Py_Expr(a, EXTRA) }
 
 expression[expr_ty]:
-    | l=expression '+' r=term { _Py_BinOp(l, Add, r, EXTRA_EXPR(l, r)) }
-    | l=expression '-' r=term { _Py_BinOp(l, Sub, r, EXTRA_EXPR(l, r)) }
+    | l=expression '+' r=term { _Py_BinOp(l, Add, r, EXTRA) }
+    | l=expression '-' r=term { _Py_BinOp(l, Sub, r, EXTRA) }
     | term
 term[expr_ty]:
-    | l=term '*' r=factor { _Py_BinOp(l, Mult, r, EXTRA_EXPR(l, r)) }
-    | l=term '/' r=factor { _Py_BinOp(l, Div, r, EXTRA_EXPR(l, r)) }
+    | l=term '*' r=factor { _Py_BinOp(l, Mult, r, EXTRA) }
+    | l=term '/' r=factor { _Py_BinOp(l, Div, r, EXTRA) }
     | factor
 factor[expr_ty]:
-    | l=primary '**' r=factor { _Py_BinOp(l, Pow, r, EXTRA_EXPR(l, r)) }
+    | l=primary '**' r=factor { _Py_BinOp(l, Pow, r, EXTRA) }
     | primary
 primary[expr_ty]:
-    | f=primary '(' e=expression ')' { _Py_Call(f, singleton_seq(p, e), NULL, EXTRA_EXPR(f, e)) }
+    | f=primary '(' e=expression ')' { _Py_Call(f, singleton_seq(p, e), NULL, EXTRA) }
     | atom
 atom[expr_ty]:
     | '(' e=expression ')' { e }

--- a/data/simpy.gram
+++ b/data/simpy.gram
@@ -20,21 +20,21 @@ small_stmt[stmt_ty]:
     | break_stmt
     | continue_stmt
     | assignment
-    | e=expressions { _Py_Expr(e, EXTRA_EXPR(e, e)) }
+    | e=expressions { _Py_Expr(e, EXTRA) }
 compound_stmt[stmt_ty]: if_stmt | while_stmt | for_stmt | with_stmt | try_stmt | function_def | class_def
 
 # NOTE: yield_expression may start with 'yield'; yield_expr must start with 'yield'
 assignment:
     | !'lambda' a=target ':' b=expression '=' c=yield_expression {
          _Py_AnnAssign(construct_assign_target(p, a), b, c,
-         a->kind == Name_kind ? 1 : 0, EXTRA_EXPR(a, c)) }
+         a->kind == Name_kind ? 1 : 0, EXTRA) }
     | !'lambda' a=target ':' b=expression {
          _Py_AnnAssign(construct_assign_target(p, a), b, NULL,
-         a->kind == Name_kind ? 1 : 0, EXTRA_EXPR(a, b)) }
+         a->kind == Name_kind ? 1 : 0, EXTRA) }
     | a=(z=star_targets '=' { z })+ b=(yield_expr | expressions) {
-         _Py_Assign(a, b, NULL, EXTRA_EXPR(seq_get_head(NULL, a), b)) }
+         _Py_Assign(a, b, NULL, EXTRA) }
     | a=target b=augassign c=(yield_expr | expressions) {
-         _Py_AugAssign(store_name(p, a), b->kind, c, EXTRA_EXPR(a, c)) }
+         _Py_AugAssign(store_name(p, a), b->kind, c, EXTRA) }
 
 augassign[AugOperator*]:
     | '+=' {augoperator(p, Add)}
@@ -52,153 +52,153 @@ augassign[AugOperator*]:
     | '//=' {augoperator(p, FloorDiv)}
 
 global_stmt[stmt_ty]: a='global' b=','.NAME+ {
-    _Py_Global(map_names_to_ids(p, b), EXTRA(a, token_type, seq_get_tail(NULL, b), expr_type)) }
+    _Py_Global(map_names_to_ids(p, b), EXTRA) }
 nonlocal_stmt[stmt_ty]: a='nonlocal' b=','.NAME+ {
-    _Py_Nonlocal(map_names_to_ids(p, b), EXTRA(a, token_type, seq_get_tail(NULL, b), expr_type)) }
+    _Py_Nonlocal(map_names_to_ids(p, b), EXTRA) }
 
-yield_stmt[stmt_ty]: y=yield_expr { _Py_Expr(y, EXTRA_EXPR(y, y)) }
+yield_stmt[stmt_ty]: y=yield_expr { _Py_Expr(y, EXTRA) }
 
 assert_stmt[stmt_ty]:
-    | a='assert' b=expression ',' c=expression { _Py_Assert(b, c, EXTRA(a, token_type, c, expr_type)) }
-    | a='assert' b=expression { _Py_Assert(b, NULL, EXTRA(a, token_type, b, expr_type)) }
+    | a='assert' b=expression ',' c=expression { _Py_Assert(b, c, EXTRA) }
+    | a='assert' b=expression { _Py_Assert(b, NULL, EXTRA) }
 
 del_stmt[stmt_ty]: a='del' b=targets { # TODO: exclude *target
-    _Py_Delete(map_targets_to_del_names(p, b), EXTRA(a, token_type, seq_get_tail(NULL, b), expr_type)) }
+    _Py_Delete(map_targets_to_del_names(p, b), EXTRA) }
 
-pass_stmt[stmt_ty]: a='pass' { _Py_Pass(EXTRA(a, token_type, a, token_type)) }
+pass_stmt[stmt_ty]: a='pass' { _Py_Pass(EXTRA) }
 
-break_stmt[stmt_ty]: a='break' { _Py_Break(EXTRA(a, token_type, a, token_type)) }
+break_stmt[stmt_ty]: a='break' { _Py_Break(EXTRA) }
 
-continue_stmt[stmt_ty]: a='continue' { _Py_Continue(EXTRA(a, token_type, a, token_type)) }
+continue_stmt[stmt_ty]: a='continue' { _Py_Continue(EXTRA) }
 
 import_stmt[stmt_ty]: import_name | import_from
 import_name[stmt_ty]: a='import' b=dotted_as_names {
-    _Py_Import(extract_orig_aliases(p, b), EXTRA(a, token_type, seq_get_tail(NULL, b), alias_type)) }
+    _Py_Import(extract_orig_aliases(p, b), EXTRA) }
 # note below: the ('.' | '...') is necessary because '...' is tokenized as ELLIPSIS
 import_from[stmt_ty]:
     | a='from' b=('.' | '...')* !'import' c=dotted_name 'import' d=import_from_targets {
         _Py_ImportFrom(c->v.Name.id,
                        extract_orig_aliases(p, d),
                        seq_count_dots(b),
-                       EXTRA(a, token_type, seq_get_tail(NULL, d), alias_type)) }
+                       EXTRA) }
     | e='from' f=('.' | '...')+ 'import' g=import_from_targets {
         _Py_ImportFrom(NULL,
                        extract_orig_aliases(p, g),
                        seq_count_dots(f), 
-                       EXTRA(e, token_type, seq_get_tail(NULL, g), alias_type)) }
+                       EXTRA) }
 import_from_targets[asdl_seq*]:
     | '(' a=import_from_as_names ')' { a }
     | import_from_as_names
     | a='*' { singleton_seq(p, pegen_alias(alias_for_star(p),
-                                           EXTRA(a, token_type, a, token_type))) }
+                                           EXTRA)) }
 import_from_as_names[asdl_seq*]:
     | a=','.import_from_as_name+ [','] { a }
 import_from_as_name[PegenAlias*]:
     | a=NAME 'as' b=NAME {
         pegen_alias(_Py_alias(((expr_ty) a)->v.Name.id, ((expr_ty) b)->v.Name.id, p->arena),
-                    EXTRA(a, expr_type, b, expr_type)) }
+                    EXTRA) }
     | a=NAME {
         pegen_alias(_Py_alias(((expr_ty) a)->v.Name.id, NULL, p->arena),
-                    EXTRA(a, expr_type, a, expr_type)) }
+                    EXTRA) }
 dotted_as_names[asdl_seq*]: 
     | a=','.dotted_as_name+ { a }
 dotted_as_name[PegenAlias*]:
     | a=dotted_name 'as' b=NAME {
         pegen_alias(_Py_alias(a->v.Name.id, ((expr_ty) b)->v.Name.id, p->arena),
-                    EXTRA(a, expr_type, b, expr_type)) }
+                    EXTRA) }
     | a=dotted_name {
         pegen_alias(_Py_alias(a->v.Name.id, NULL, p->arena),
-                    EXTRA(a, expr_type, a, expr_type)) }
+                    EXTRA) }
 dotted_name[expr_ty]:
     | a=dotted_name '.' b=NAME { join_names_with_dot(p, a, b) }
     | NAME
 
 if_stmt[stmt_ty]:
     | a='if' b=named_expression ':' c=block d=else_block {
-        _Py_If(b, c, d, EXTRA(a, token_type, seq_get_tail(NULL, d), stmt_type)) }
+        _Py_If(b, c, d, EXTRA) }
     | a='if' b=named_expression ':' c=block e=elif_stmt {
-        _Py_If(b, c, singleton_seq(p, e), EXTRA(a, token_type, e, stmt_type)) }
+        _Py_If(b, c, singleton_seq(p, e), EXTRA) }
     | a='if' b=named_expression ':' c=block {
-        _Py_If(b, c, NULL, EXTRA(a, token_type, seq_get_tail(NULL, c), stmt_type)) }
+        _Py_If(b, c, NULL, EXTRA) }
 elif_stmt[stmt_ty]:
     | 'elif' b=named_expression ':' c=block d=else_block {
-        _Py_If(b, c, d, EXTRA(b, expr_type, seq_get_tail(NULL, d), stmt_type)) }
+        _Py_If(b, c, d, EXTRA) }
     | 'elif' b=named_expression ':' c=block e=elif_stmt {
-        _Py_If(b, c, singleton_seq(p, e), EXTRA(b, expr_type, e, stmt_type)) }
+        _Py_If(b, c, singleton_seq(p, e), EXTRA) }
     | 'elif' b=named_expression ':' c=block {
-        _Py_If(b, c, NULL, EXTRA(b, expr_type, seq_get_tail(NULL, c), stmt_type)) }
+        _Py_If(b, c, NULL, EXTRA) }
 else_block[asdl_seq*]: 'else' ':' b=block { b }
 
 while_stmt[stmt_ty]:
     | a='while' ex=named_expression ':' b=block el=else_block {
-        _Py_While(ex, b, el, EXTRA(a, token_type, seq_get_tail(NULL, el), stmt_type)) }
+        _Py_While(ex, b, el, EXTRA) }
     | a='while' ex=named_expression ':' b=block {
-        _Py_While(ex, b, NULL, EXTRA(a, token_type, seq_get_tail(NULL, b), stmt_type)) }
+        _Py_While(ex, b, NULL, EXTRA) }
 
 for_stmt[stmt_ty]:
     | a=ASYNC 'for' t=star_targets 'in' ex=expressions ':' b=block el=else_block {
-        _Py_AsyncFor(t, ex, b, el, NULL, EXTRA(a, token_type, seq_get_tail(NULL, el), stmt_type)) }
+        _Py_AsyncFor(t, ex, b, el, NULL, EXTRA) }
     | a=ASYNC 'for' t=star_targets 'in' ex=expressions ':' b=block {
-        _Py_AsyncFor(t, ex, b, NULL, NULL, EXTRA(a, token_type, seq_get_tail(NULL, b), stmt_type)) }
+        _Py_AsyncFor(t, ex, b, NULL, NULL, EXTRA) }
     | a='for' t=star_targets 'in' ex=expressions ':' b=block el=else_block {
-        _Py_For(t, ex, b, el, NULL, EXTRA(a, token_type, seq_get_tail(NULL, el), stmt_type)) }
+        _Py_For(t, ex, b, el, NULL, EXTRA) }
     | a='for' t=star_targets 'in' ex=expressions ':' b=block {
-        _Py_For(t, ex, b, NULL, NULL, EXTRA(a, token_type, seq_get_tail(NULL, b), stmt_type)) }
+        _Py_For(t, ex, b, NULL, NULL, EXTRA) }
 
 with_stmt[stmt_ty]:
     | a=ASYNC 'with' '(' b=','.with_item+ ')' ':' c=block {
-        _Py_AsyncWith(b, c, NULL, EXTRA(a, token_type, seq_get_tail(NULL, c), stmt_type)) }
+        _Py_AsyncWith(b, c, NULL, EXTRA) }
     | a=ASYNC 'with' b=','.with_item+ ':' c=block {
-        _Py_AsyncWith(b, c, NULL, EXTRA(a, token_type, seq_get_tail(NULL, c), stmt_type)) }
+        _Py_AsyncWith(b, c, NULL, EXTRA) }
     | a='with' '(' b=','.with_item+ ')' ':' c=block {
-        _Py_With(b, c, NULL, EXTRA(a, token_type, seq_get_tail(NULL, c), stmt_type)) }
+        _Py_With(b, c, NULL, EXTRA) }
     | a='with' b=','.with_item+ ':' c=block {
-        _Py_With(b, c, NULL, EXTRA(a, token_type, seq_get_tail(NULL, c), stmt_type)) }
+        _Py_With(b, c, NULL, EXTRA) }
 with_item[withitem_ty]:
     | e=expression o=['as' t=target { t }] { _Py_withitem(e, store_name(p, o), p->arena) }
 
 try_stmt[stmt_ty]:
     | a='try' ':' b=block ex=except_block+ el=else_block f=finally_block {
-        _Py_Try(b, ex, el, f, EXTRA(a, token_type, seq_get_tail(NULL, f), stmt_type)) }
+        _Py_Try(b, ex, el, f, EXTRA) }
     | a='try' ':' b=block ex=except_block+ el=else_block {
-        _Py_Try(b, ex, el, NULL, EXTRA(a, token_type, seq_get_tail(NULL, el), stmt_type)) }
+        _Py_Try(b, ex, el, NULL, EXTRA) }
     | a='try' ':' b=block ex=except_block+ f=finally_block {
-        _Py_Try(b, ex, NULL, f, EXTRA(a, token_type, seq_get_tail(NULL, f), stmt_type)) }
+        _Py_Try(b, ex, NULL, f, EXTRA) }
     | a='try' ':' b=block ex=except_block+ {
-        _Py_Try(b, ex, NULL, NULL, EXTRA(a, token_type, seq_get_tail(NULL, ex), excepthandler_type)) }
+        _Py_Try(b, ex, NULL, NULL, EXTRA) }
     | a='try' ':' b=block f=finally_block {
-        _Py_Try(b, NULL, NULL, f, EXTRA(a, token_type, seq_get_tail(NULL, f), stmt_type)) }
+        _Py_Try(b, NULL, NULL, f, EXTRA) }
 except_block[excepthandler_ty]:
     | a='except' e=expression 'as' t=target ':' b=block {
-        _Py_ExceptHandler(e, t->v.Name.id, b, EXTRA(a, token_type, seq_get_tail(NULL, b), stmt_type)) }
+        _Py_ExceptHandler(e, t->v.Name.id, b, EXTRA) }
     | a='except' e=expression ':' b=block {
-        _Py_ExceptHandler(e, NULL, b, EXTRA(a, token_type, seq_get_tail(NULL, b), stmt_type)) }
+        _Py_ExceptHandler(e, NULL, b, EXTRA) }
     | a='except' ':' b=block {
-        _Py_ExceptHandler(NULL, NULL, b, EXTRA(a, token_type, seq_get_tail(NULL, b), stmt_type)) }
+        _Py_ExceptHandler(NULL, NULL, b, EXTRA) }
 finally_block[asdl_seq*]: 'finally' ':' a=block { a }
 
 return_stmt[stmt_ty]:
-    | a='return' b=expressions { _Py_Return(b, EXTRA(a, token_type, b, expr_type)) }
-    | a='return' { _Py_Return(NULL, EXTRA(a, token_type, a, token_type)) }
+    | a='return' b=expressions { _Py_Return(b, EXTRA) }
+    | a='return' { _Py_Return(NULL, EXTRA) }
 
 raise_stmt[stmt_ty]:
-    | a='raise' b=expression 'from' c=expression { _Py_Raise(b, c, EXTRA(a, token_type, c, expr_type)) }
-    | a='raise' b=expression { _Py_Raise(b, NULL, EXTRA(a, token_type, b, expr_type)) }
-    | a='raise' { _Py_Raise(NULL, NULL, EXTRA(a, token_type, a, token_type)) }
+    | a='raise' b=expression 'from' c=expression { _Py_Raise(b, c, EXTRA) }
+    | a='raise' b=expression { _Py_Raise(b, NULL, EXTRA) }
+    | a='raise' { _Py_Raise(NULL, NULL, EXTRA) }
 
 function_def[stmt_ty]:
-    | d=[decorators] s=ASYNC 'def' n=NAME '(' params=parameters ')' a=['->' z=annotation { z }] ':' b=block {
-        _Py_AsyncFunctionDef(((expr_ty) n)->v.Name.id, params, b, d, a, NULL,
-                             EXTRA(s, token_type, seq_get_tail(NULL, b), stmt_type)) }
-    | d=[decorators] s=ASYNC 'def' n=NAME '(' ')' a=['->' z=annotation { z }] ':' b=block {
-        _Py_AsyncFunctionDef(((expr_ty) n)->v.Name.id, empty_arguments(p), b, d, a, NULL,
-                             EXTRA(s, token_type, seq_get_tail(NULL, b), stmt_type)) }
-    | d=[decorators] s='def' n=NAME '(' params=parameters ')' a=['->' z=annotation { z }] ':' b=block {
-        _Py_FunctionDef(((expr_ty) n)->v.Name.id, params, b, d, a, NULL,
-                        EXTRA(s, token_type, seq_get_tail(NULL, b), stmt_type)) }
-    | d=[decorators] s='def' n=NAME '(' ')' a=['->' z=annotation { z }] ':' b=block {
-        _Py_FunctionDef(((expr_ty) n)->v.Name.id, empty_arguments(p), b, d, a, NULL,
-                        EXTRA(s, token_type, seq_get_tail(NULL, b), stmt_type)) }
+    | d=decorators f=function_def_raw { function_def_decorators(p, d, f) }
+    | function_def_raw
+
+function_def_raw[stmt_ty]:
+    | s=ASYNC 'def' n=NAME '(' params=parameters ')' a=['->' z=annotation { z }] ':' b=block {
+        _Py_AsyncFunctionDef(((expr_ty) n)->v.Name.id, params, b, NULL, a, NULL, EXTRA) }
+    | s=ASYNC 'def' n=NAME '(' ')' a=['->' z=annotation { z }] ':' b=block {
+        _Py_AsyncFunctionDef(((expr_ty) n)->v.Name.id, empty_arguments(p), b, NULL, a, NULL, EXTRA) }
+    | s='def' n=NAME '(' params=parameters ')' a=['->' z=annotation { z }] ':' b=block {
+        _Py_FunctionDef(((expr_ty) n)->v.Name.id, params, b, NULL, a, NULL, EXTRA) }
+    | s='def' n=NAME '(' ')' a=['->' z=annotation { z }] ':' b=block {
+        _Py_FunctionDef(((expr_ty) n)->v.Name.id, empty_arguments(p), b, NULL, a, NULL, EXTRA) }
 
 parameters[arguments_ty]:
     | a=slash_without_default b=[',' x=plain_names { x }] c=[',' y=names_with_default { y }] d=[',' z=[star_etc] { z }] {
@@ -225,11 +225,10 @@ name_with_default[NameDefaultPair*]:
     | n=plain_name '=' e=expression { name_default_pair(p, n, e) }
 plain_names[asdl_seq*]: a=','.(plain_name !'=')+ { a }
 plain_name[arg_ty]:
-    | a=NAME ':' b=annotation { _Py_arg(((expr_ty) a)->v.Name.id, b, NULL, EXTRA_EXPR(a, b)) }
-    | a=NAME { _Py_arg(((expr_ty) a)->v.Name.id, NULL, NULL, EXTRA_EXPR(a, a)) }
+    | a=NAME ':' b=annotation { _Py_arg(((expr_ty) a)->v.Name.id, b, NULL, EXTRA) }
+    | a=NAME { _Py_arg(((expr_ty) a)->v.Name.id, NULL, NULL, EXTRA) }
 kwds[arg_ty]:
-    | '**' a=NAME ':' b=annotation { _Py_arg(((expr_ty) a)->v.Name.id, b, NULL, EXTRA_EXPR(a, b)) }
-    | '**' a=NAME { _Py_arg(((expr_ty) a)->v.Name.id, NULL, NULL, EXTRA_EXPR(a, a)) }
+    | '**' a=plain_name { a }
 annotation[expr_ty]: expression
 
 decorators[asdl_seq*]: a=('@' f=factor NEWLINE { f })+ { a }
@@ -241,29 +240,29 @@ block[asdl_seq*]: simple_stmt | NEWLINE INDENT a=statements DEDENT { a }
 expressions_list[asdl_seq*]: a=','.star_expression+ [','] { a }
 expressions[expr_ty]:
     | a=star_expression b=(',' c=star_expression { c })+ [','] {
-        _Py_Tuple(seq_insert_in_front(p, a, b), Load, EXTRA_EXPR(a, seq_get_tail(NULL, b))) }
-    | a=star_expression ',' { _Py_Tuple(singleton_seq(p, a), Load, EXTRA_EXPR(a, a)) }
+        _Py_Tuple(seq_insert_in_front(p, a, b), Load, EXTRA) }
+    | a=star_expression ',' { _Py_Tuple(singleton_seq(p, a), Load, EXTRA) }
     | star_expression
 star_expression[expr_ty]:
-    | a='*' b=bitwise_or { _Py_Starred(b, Load, EXTRA(a, token_type, b, expr_type)) }
+    | a='*' b=bitwise_or { _Py_Starred(b, Load, EXTRA) }
     | expression
 
 star_named_expressions[asdl_seq*]: a=','.star_named_expression+ [','] { a }
 star_named_expression[expr_ty]:
-    | a='*' b=bitwise_or { _Py_Starred(b, Load, EXTRA(a, token_type, b, expr_type)) }
+    | a='*' b=bitwise_or { _Py_Starred(b, Load, EXTRA) }
     | named_expression
 named_expression[expr_ty]:
-    | a=NAME ':=' b=expression { _Py_NamedExpr(a, b, EXTRA_EXPR(a, b)) }
+    | a=NAME ':=' b=expression { _Py_NamedExpr(a, b, EXTRA) }
     | expression
 yield_expression: yield_expr | expression
 expression[expr_ty]:
     | lambdef
-    | a=disjunction 'if' b=disjunction 'else' c=expression { _Py_IfExp(b, a, c, EXTRA_EXPR(a, c)) }
+    | a=disjunction 'if' b=disjunction 'else' c=expression { _Py_IfExp(b, a, c, EXTRA) }
     | disjunction
 
-lambdef[expr_ty]: 
-    | a='lambda' ':' c=expression {_Py_Lambda(empty_arguments(p), c, EXTRA(a, token_type, c, expr_type))}
-    | a='lambda' b=lambda_parameters ':' c=expression {_Py_Lambda(b, c, EXTRA(a, token_type, c, expr_type))}
+lambdef[expr_ty]:
+    | a='lambda' ':' c=expression { _Py_Lambda(empty_arguments(p), c, EXTRA) }
+    | a='lambda' b=lambda_parameters ':' c=expression { _Py_Lambda(b, c, EXTRA) }
 lambda_parameters[arguments_ty]:
     | a=lambda_slash_without_default b=[',' x=lambda_plain_names { x }] c=[',' y=lambda_names_with_default { y }] d=[',' z=[lambda_star_etc] { z }] {
         make_arguments(p, a, NULL, b, c, d) }
@@ -288,23 +287,23 @@ lambda_names_with_default[asdl_seq*]: a=','.lambda_name_with_default+ { a }
 lambda_name_with_default[NameDefaultPair*]:
     | n=lambda_plain_name '=' e=expression { name_default_pair(p, n, e) }
 lambda_plain_names[asdl_seq*]: a=','.(lambda_plain_name !'=')+ { a }
-lambda_plain_name[arg_ty]: a=NAME { _Py_arg(((expr_ty) a)->v.Name.id, NULL, NULL, EXTRA_EXPR(a, a)) }
-lambda_kwds[arg_ty]: '**' a=NAME { _Py_arg(((expr_ty) a)->v.Name.id, NULL, NULL, EXTRA_EXPR(a, a)) }
+lambda_plain_name[arg_ty]: a=NAME { _Py_arg(((expr_ty) a)->v.Name.id, NULL, NULL, EXTRA) }
+lambda_kwds[arg_ty]: '**' a=lambda_plain_name { a }
 
 disjunction[expr_ty]:
     | a=conjunction b=('or' c=conjunction { c })+ { _Py_BoolOp(
         Or,
         seq_insert_in_front(p, a, b),
-        EXTRA_EXPR(a, seq_get_tail(NULL, b))) }
+        EXTRA) }
     | conjunction
 conjunction[expr_ty]:
     | a=inversion b=('and' c=inversion { c })+ { _Py_BoolOp(
         And,
         seq_insert_in_front(p, a, b),
-        EXTRA_EXPR(a, seq_get_tail(NULL, b))) }
+        EXTRA) }
     | inversion
 inversion[expr_ty]:
-    | a='not' b=inversion { _Py_UnaryOp(Not, b, EXTRA(a, token_type, b, expr_type)) }
+    | a='not' b=inversion { _Py_UnaryOp(Not, b, EXTRA) }
     | comparison
 comparison[expr_ty]:
     | a=bitwise_or b=compare_op_bitwise_or_pair+ {
@@ -333,37 +332,37 @@ isnot_bitwise_or[CmpopExprPair*]: 'is' 'not' a=bitwise_or { cmpop_expr_pair(p, I
 is_bitwise_or[CmpopExprPair*]: 'is' a=bitwise_or { cmpop_expr_pair(p, Is, a) }
 
 bitwise_or[expr_ty]: 
-    | a=bitwise_or '|' b=bitwise_xor { _Py_BinOp(a, BitOr, b, EXTRA_EXPR(a, b)) }
+    | a=bitwise_or '|' b=bitwise_xor { _Py_BinOp(a, BitOr, b, EXTRA) }
     | bitwise_xor
 bitwise_xor[expr_ty]:
-    | a=bitwise_xor '^' b=bitwise_and { _Py_BinOp(a, BitXor, b, EXTRA_EXPR(a, b)) }
+    | a=bitwise_xor '^' b=bitwise_and { _Py_BinOp(a, BitXor, b, EXTRA) }
     | bitwise_and 
 bitwise_and[expr_ty]:
-    | a=bitwise_and '&' b=shift_expr { _Py_BinOp(a, BitAnd, b, EXTRA_EXPR(a, b)) }
+    | a=bitwise_and '&' b=shift_expr { _Py_BinOp(a, BitAnd, b, EXTRA) }
     | shift_expr 
 shift_expr[expr_ty]:
-    | a=shift_expr '<<' b=sum { _Py_BinOp(a, LShift, b, EXTRA_EXPR(a, b)) }
-    | a=shift_expr '>>' b=sum { _Py_BinOp(a, RShift, b, EXTRA_EXPR(a, b)) }
+    | a=shift_expr '<<' b=sum { _Py_BinOp(a, LShift, b, EXTRA) }
+    | a=shift_expr '>>' b=sum { _Py_BinOp(a, RShift, b, EXTRA) }
     | sum
 
 sum[expr_ty]:
-    | a=sum '+' b=term { _Py_BinOp(a, Add, b, EXTRA_EXPR(a, b)) }
-    | a=sum '-' b=term { _Py_BinOp(a, Sub, b, EXTRA_EXPR(a, b)) }
+    | a=sum '+' b=term { _Py_BinOp(a, Add, b, EXTRA) }
+    | a=sum '-' b=term { _Py_BinOp(a, Sub, b, EXTRA) }
     | term
 term[expr_ty]:
-    | a=term '*' b=factor { _Py_BinOp(a, Mult, b, EXTRA_EXPR(a, b)) }
-    | a=term '/' b=factor { _Py_BinOp(a, Div, b, EXTRA_EXPR(a, b)) }
-    | a=term '//' b=factor { _Py_BinOp(a, FloorDiv, b, EXTRA_EXPR(a, b)) }
-    | a=term '%' b=factor { _Py_BinOp(a, Mod, b, EXTRA_EXPR(a, b)) }
-    | a=term '@' b=factor { _Py_BinOp(a, MatMult, b, EXTRA_EXPR(a, b)) }
+    | a=term '*' b=factor { _Py_BinOp(a, Mult, b, EXTRA) }
+    | a=term '/' b=factor { _Py_BinOp(a, Div, b, EXTRA) }
+    | a=term '//' b=factor { _Py_BinOp(a, FloorDiv, b, EXTRA) }
+    | a=term '%' b=factor { _Py_BinOp(a, Mod, b, EXTRA) }
+    | a=term '@' b=factor { _Py_BinOp(a, MatMult, b, EXTRA) }
     | factor
 factor[expr_ty]:
-    | a='+' b=factor { _Py_UnaryOp(UAdd, b, EXTRA(a, token_type, b, expr_type)) }
-    | a='-' b=factor { _Py_UnaryOp(USub, b, EXTRA(a, token_type, b, expr_type)) }
-    | a='~' b=factor { _Py_UnaryOp(Invert, b, EXTRA(a, token_type, b, expr_type)) }
+    | a='+' b=factor { _Py_UnaryOp(UAdd, b, EXTRA) }
+    | a='-' b=factor { _Py_UnaryOp(USub, b, EXTRA) }
+    | a='~' b=factor { _Py_UnaryOp(Invert, b, EXTRA) }
     | power
 power[expr_ty]:
-    | a=primary '**' b=factor { _Py_BinOp(a, Pow, b, EXTRA_EXPR(a, b)) }
+    | a=primary '**' b=factor { _Py_BinOp(a, Pow, b, EXTRA) }
     | primary 
 primary[expr_ty]:
     | !'await' a=atom !'.' !'(' !'[' { a }
@@ -385,25 +384,25 @@ atom[expr_ty]:
     | NAME
     | a=STRING+ { asdl_seq_GET(a, 0) }
     | NUMBER
-    | a='...' { _Py_Constant(Py_Ellipsis, NULL, EXTRA(a, token_type, a, token_type)) }
+    | a='...' { _Py_Constant(Py_Ellipsis, NULL, EXTRA) }
 
 list[expr_ty]:
-    | a='[' b=[star_named_expressions] c=']' { _Py_List(b, Load, EXTRA(a, token_type, c, token_type)) }
+    | a='[' b=[star_named_expressions] c=']' { _Py_List(b, Load, EXTRA) }
 listcomp[expr_ty]:
-    | a='[' b=named_expression c=for_if_clauses d=']' { _Py_ListComp(b, c, EXTRA(a, token_type, d, token_type)) }
+    | a='[' b=named_expression c=for_if_clauses d=']' { _Py_ListComp(b, c, EXTRA) }
 tuple[expr_ty]:
     | a='(' b=[y=star_named_expression ',' z=[star_named_expressions] { seq_insert_in_front(p, y, z)} ] c=')' {
-        _Py_Tuple(b, Load, EXTRA(a, token_type, c, token_type)) }
+        _Py_Tuple(b, Load, EXTRA) }
 group[expr_ty]: '(' a=(yield_expr | named_expression) ')' { a }
 genexp[expr_ty]:
-    | a='(' b=expression c=for_if_clauses d=')' { _Py_GeneratorExp(b, c, EXTRA(a, token_type, d, token_type)) }
-set[expr_ty]: a='{' b=expressions_list c='}' { _Py_Set(b, EXTRA(a, token_type, c, token_type)) }
+    | a='(' b=expression c=for_if_clauses d=')' { _Py_GeneratorExp(b, c, EXTRA) }
+set[expr_ty]: a='{' b=expressions_list c='}' { _Py_Set(b, EXTRA) }
 setcomp[expr_ty]:
-    | a='{' b=expression c=for_if_clauses d='}' { _Py_SetComp(b, c, EXTRA(a, token_type, d, token_type)) }
+    | a='{' b=expression c=for_if_clauses d='}' { _Py_SetComp(b, c, EXTRA) }
 dict[expr_ty]:
-    | a='{' b=[kvpairs] c='}' { _Py_Dict(get_keys(p, b), get_values(p, b), EXTRA(a, token_type, c, token_type)) }
+    | a='{' b=[kvpairs] c='}' { _Py_Dict(get_keys(p, b), get_values(p, b), EXTRA) }
 dictcomp[expr_ty]:
-    | a='{' b=kvpair c=for_if_clauses d='}' { _Py_DictComp(b->key, b->value, c, EXTRA(a, token_type, d, token_type)) }
+    | a='{' b=kvpair c=for_if_clauses d='}' { _Py_DictComp(b->key, b->value, c, EXTRA) }
 kvpairs[asdl_seq*]: a=','.kvpair+ [','] { a }
 kvpair[KeyValuePair*]:
     | '**' a=bitwise_or { key_value_pair(p, NULL, a) }
@@ -413,9 +412,9 @@ for_if_clauses[asdl_seq*]:
         { _Py_comprehension(a, b, c, (y == NULL) ? 0 : 1, p->arena) })+ { a }
 
 yield_expr[expr_ty]:
-    | a='yield' 'from' b=expression { _Py_YieldFrom(b, EXTRA(a, token_type, b, expr_type)) }
-    | a='yield' b=expressions { _Py_Yield(b, EXTRA(a, token_type, b, expr_type)) }
-    | a='yield' { _Py_Yield(NULL, EXTRA(a, token_type, a, token_type)) }
+    | a='yield' 'from' b=expression { _Py_YieldFrom(b, EXTRA) }
+    | a='yield' b=expressions { _Py_Yield(b, EXTRA) }
+    | a='yield' { _Py_Yield(NULL, EXTRA) }
 
 arguments: expression for_if_clauses | args [',']
 args: '*' expression [',' args] | kwargs | posarg [',' args]  # Weird to make it work
@@ -434,8 +433,8 @@ targets[asdl_seq*]: a=','.target+ [','] { a }
 target[expr_ty]: atom t_tail+ | a=t_atom t_tail* { a }
 t_atom[expr_ty]:
     | NAME
-    | a='(' b=[targets] c=')' { _Py_Tuple(b, Load, EXTRA(a, token_type, c, token_type)) }
-    | a='[' b=[targets] c=']' { _Py_List(b, Load, EXTRA(a, token_type, c, token_type)) }
+    | a='(' b=[targets] c=')' { _Py_Tuple(b, Load, EXTRA) }
+    | a='[' b=[targets] c=']' { _Py_List(b, Load, EXTRA) }
 
 t_tail: call_tail* (attr_tail | index_tail)
 call_tail: '(' ~ [arguments] ')'

--- a/pegen/pegen.h
+++ b/pegen/pegen.h
@@ -70,7 +70,8 @@ int lookahead_with_int(int, Token *(func)(Parser *, int), Parser *, int);
 int lookahead(int, void *(func)(Parser *), Parser *);
 
 Token *expect_token(Parser *p, int type);
-
+Token *get_last_nonnwhitespace_token(Parser *);
+int fill_token(Parser *p);
 void *async_token(Parser *p);
 void *await_token(Parser *p);
 void *endmarker_token(Parser *p);
@@ -85,12 +86,9 @@ int raise_syntax_error(Parser *p, const char *errmsg, ...);
 
 void *CONSTRUCTOR(Parser *p, ...);
 
-#define EXTRA_EXPR(head, tail) EXTRA(head, expr_type, tail, expr_type)
-#define EXTRA(head, head_type_func, tail, tail_type_func) head_type_func##_headline(head), \
-                                                          head_type_func##_headcol(head), \
-                                                          tail_type_func##_tailline(tail), \
-                                                          tail_type_func##_tailcol(tail), \
-                                                          p->arena
+#define UNUSED(expr) do { (void)(expr); } while (0)
+#define EXTRA_EXPR(head, tail) head->lineno, head->col_offset, tail->end_lineno, tail->end_col_offset, p->arena
+#define EXTRA start_lineno, start_col_offset, end_lineno, end_col_offset, p->arena
 
 PyObject *run_parser_from_file(const char *filename, void *(start_rule_func)(Parser *), int mode);
 PyObject *run_parser_from_string(const char *str, void *(start_rule_func)(Parser *), int mode);
@@ -120,24 +118,4 @@ arguments_ty make_arguments(Parser *, asdl_seq *, SlashWithDefault *,
 arguments_ty empty_arguments(Parser *);
 AugOperator *augoperator(Parser*, operator_ty type);
 expr_ty construct_assign_target(Parser *p, expr_ty node);
-
-inline int expr_type_headline(expr_ty a) { return a->lineno; }
-inline int expr_type_headcol(expr_ty a) { return a->col_offset; }
-inline int expr_type_tailline(expr_ty a) { return a->end_lineno; }
-inline int expr_type_tailcol(expr_ty a) { return a->end_col_offset; }
-inline int stmt_type_headline(stmt_ty a) { return a->lineno; }
-inline int stmt_type_headcol(stmt_ty a) { return a->col_offset; }
-inline int stmt_type_tailline(stmt_ty a) { return a->end_lineno; }
-inline int stmt_type_tailcol(stmt_ty a) { return a->end_col_offset; }
-inline int excepthandler_type_headline(excepthandler_ty a) { return a->lineno; }
-inline int excepthandler_type_headcol(excepthandler_ty a) { return a->col_offset; }
-inline int excepthandler_type_tailline(excepthandler_ty a) { return a->end_lineno; }
-inline int excepthandler_type_tailcol(excepthandler_ty a) { return a->end_col_offset; }
-inline int token_type_headline(Token *a) { return a->lineno; }
-inline int token_type_headcol(Token *a) { return a->col_offset; }
-inline int token_type_tailline(Token *a) { return a->end_lineno; }
-inline int token_type_tailcol(Token *a) { return a->end_col_offset; }
-inline int alias_type_headline(PegenAlias *a) { return a->lineno; }
-inline int alias_type_headcol(PegenAlias *a) { return a->col_offset; }
-inline int alias_type_tailline(PegenAlias *a) { return a->end_lineno; }
-inline int alias_type_tailcol(PegenAlias *a) { return a->end_col_offset; }
+stmt_ty function_def_decorators(Parser *, asdl_seq *, stmt_ty);

--- a/test/test_ast_generation.py
+++ b/test/test_ast_generation.py
@@ -37,8 +37,6 @@ def parser_extension(tmp_path_factory: Any) -> Any:
 
 @pytest.mark.parametrize("filename", PYTHON_SOURCE_FILENAMES)
 def test_ast_generation_on_source_files(parser_extension: Any, filename: PurePath) -> None:
-    if filename == "group.py":
-        pytest.skip("AST Generation for groups can fail. See #107 on Github.")
     source = read_python_source(os.path.join(TEST_DIR, filename))
 
     actual_ast = parser_extension.parse_string(source)
@@ -46,14 +44,3 @@ def test_ast_generation_on_source_files(parser_extension: Any, filename: PurePat
     assert ast.dump(actual_ast, include_attributes=True) == ast.dump(
         expected_ast, include_attributes=True
     ), f"Wrong AST generation for file: {filename}"
-
-
-@pytest.mark.xfail(strict=True)
-def test_ast_generation_group(parser_extension: Any) -> None:
-    source = read_python_source(os.path.join(TEST_DIR, "group.py"))
-
-    actual_ast = parser_extension.parse_string(source)
-    expected_ast = ast.parse(source)
-    assert ast.dump(actual_ast, include_attributes=True) == ast.dump(
-        expected_ast, include_attributes=True
-    ), f"Wrong AST generation for file: group.py"


### PR DESCRIPTION
…121)

* Keep EXTRA_EXPR for use in pegen.c, refactor get_last_nonwhitespace_token to use a for-loop
* Use 3.8-dev on Travis for the latest AST bugfixes
* Refactor lambda rules to use the new EXTRA macro
* Refactor cprog.gram to use new EXTRA macro