### PR TITLE
Refactor rules for class_def and arguments (#135)

### DIFF
--- a/data/simpy.gram
+++ b/data/simpy.gram
@@ -184,7 +184,15 @@ annotation[expr_ty]: expression
 
 decorators[asdl_seq*]: a=('@' f=factor NEWLINE { f })+ { a }
 
-class_def: [decorators] 'class' NAME ['(' [arguments] ')'] ':' block
+class_def[stmt_ty]:
+    | a=decorators b=class_def_raw { class_def_decorators(p, a, b) }
+    | class_def_raw
+class_def_raw[stmt_ty]:
+    | 'class' a=NAME b=['(' z=[class_arguments] ')' { z }] ':' c=block {
+        _Py_ClassDef(((expr_ty) a)->v.Name.id,
+                     (b) ? ((expr_ty) b)->v.Call.args : NULL,
+                     (b) ? ((expr_ty) b)->v.Call.keywords : NULL,
+                     c, NULL, EXTRA) }
 
 block[asdl_seq*]: simple_stmt | NEWLINE INDENT a=statements DEDENT { a }
 
@@ -365,11 +373,36 @@ yield_expr[expr_ty]:
     | 'yield' 'from' a=expression { _Py_YieldFrom(a, EXTRA) }
     | 'yield' a=[expressions] { _Py_Yield(a, EXTRA) }
 
-arguments: expression for_if_clauses | args [',']
-args: '*' expression [',' args] | kwargs | posarg [',' args]  # Weird to make it work
-kwargs: ','.kwarg+
-posarg: named_expression | '*' expression
-kwarg: NAME '=' expression | '*' expression | '**' expression
+class_arguments[expr_ty]: a=args [','] { a }
+arguments[expr_ty]:
+    | a=expression b=for_if_clauses { _Py_Call(CONSTRUCTOR(p),
+                                               singleton_seq(p, _Py_GeneratorExp(a, b, EXTRA)),
+                                               NULL,
+                                               EXTRA) }
+    | a=args [','] { a }
+args[expr_ty]:
+    | a=starred_expression b=[',' c=args { c }] {
+        _Py_Call(CONSTRUCTOR(p),
+                 (b) ? seq_insert_in_front(p, a, ((expr_ty) b)->v.Call.args) : singleton_seq(p, a),
+                 (b) ? ((expr_ty) b)->v.Call.keywords : NULL,
+                 EXTRA) }
+    | a=kwargs { _Py_Call(CONSTRUCTOR(p),
+                          seq_extract_starred_exprs(p, a),
+                          seq_delete_starred_exprs(p, a),
+                          EXTRA) }
+    | a=named_expression b=[',' c=args { c }] {
+        _Py_Call(CONSTRUCTOR(p),
+                 (b) ? seq_insert_in_front(p, a, ((expr_ty) b)->v.Call.args) : singleton_seq(p, a),
+                 (b) ? ((expr_ty) b)->v.Call.keywords : NULL,
+                 EXTRA) }
+kwargs[asdl_seq*]: a=','.kwarg+ { a }
+starred_expression[expr_ty]:
+    | '*' a=expression { _Py_Starred(a, Load, EXTRA) }
+kwarg[KeywordOrStarred*]:
+    | a=NAME '=' b=expression {
+        keyword_or_starred(p, _Py_keyword(((expr_ty) a)->v.Name.id, b, p->arena), 1) }
+    | a=starred_expression { keyword_or_starred(p, a, 0) }
+    | '**' a=expression { keyword_or_starred(p, _Py_keyword(NULL, a, p->arena), 1) }
 
 # NOTE: star_targets may contain *NAME, targets may not.
 # NOTE: the !'in' is to handle "for x, in ...".

--- a/docs/helpers.md
+++ b/docs/helpers.md
@@ -83,6 +83,14 @@ Used to encapsulate the value of an operator_ty enum value.
 
 - kind: operator_ty, The augmented assignment operator
 
+#### KeywordOrStarred
+
+This is needed by the `arguments` rule, because a starred expression can appear
+after the first keyword argument has been parsed.
+
+- elem: `void *`, The keyword argument or starred expression itself
+- is_keyword: `int` (`bool`), Must be 0 for `*args`, 1 for `kw=expr` and `**kwargs`
+
 
 Helper Functions
 ----------------
@@ -152,3 +160,15 @@ Constructs an empty `arguments_ty` object, that gets used when a function accept
 
 ###### `asdl_seq *augoperator(Parser *p, operator_ty kind)`
 Creates an `AugOperator` encapsulating the operator type provided in *kind*.
+
+###### `stmt_ty function_def_decorators(Parser *p, asdl_seq *decorators, stmt_ty function_def)`
+Construct a `FunctionDef` equivalent to `function_def`, but with `decorators`.
+
+###### `stmt_ty class_def_decorators(Parser *p, asdl_seq *decorators, stmt_ty class_def)`
+Construct a `ClassDef` equivalent to `class_def`, but with `decorators`.
+
+###### `asdl_seq *seq_extract_starred_exprs(Parser *p, asdl_seq *kwargs)`
+Extract the starred expressions of an `asdl_seq*` of `KeywordOrStarred*`s.
+
+###### `asdl_seq *seq_delete_starred_exprs(Parser *p, asdl_seq *kwargs)`
+Return a new `asdl_seq*` with only the keywords in `kwargs`.

--- a/pegen/pegen.h
+++ b/pegen/pegen.h
@@ -56,6 +56,11 @@ typedef struct {
     operator_ty kind;
 } AugOperator;
 
+typedef struct {
+    void *element;
+    int is_keyword;
+} KeywordOrStarred;
+
 int insert_memo(Parser *p, int mark, int type, void *node);
 int update_memo(Parser *p, int mark, int type, void *node);
 int is_memoized(Parser *p, int type, void *pres);
@@ -112,3 +117,7 @@ arguments_ty empty_arguments(Parser *);
 AugOperator *augoperator(Parser*, operator_ty type);
 expr_ty construct_assign_target(Parser *p, expr_ty node);
 stmt_ty function_def_decorators(Parser *, asdl_seq *, stmt_ty);
+stmt_ty class_def_decorators(Parser *, asdl_seq *, stmt_ty);
+KeywordOrStarred *keyword_or_starred(Parser *, void *, int);
+asdl_seq *seq_extract_starred_exprs(Parser *, asdl_seq *);
+asdl_seq *seq_delete_starred_exprs(Parser *, asdl_seq *);

--- a/test/test_ast_generation.py
+++ b/test/test_ast_generation.py
@@ -31,6 +31,42 @@ TEST_CASES = [
     ('binop_boolop_comp', '1 + 1 == 2 or 1 + 1 == 3 and not b'),
     ('boolop_or', 'a or b'),
     ('boolop_or_multiple', 'a or b or c'),
+    ('class_def_bases',
+     '''
+        class C(A, B):
+            pass
+     '''),
+    ('class_def_decorators',
+     '''
+        @a
+        class C:
+            pass
+     '''),
+    ('class_def_keywords',
+     '''
+        class C(keyword=a+b, **c):
+            pass
+     '''),
+    ('class_def_mixed',
+     '''
+        class C(A, B, keyword=0, **a):
+            pass
+     '''),
+    ('class_def_simple',
+     '''
+        class C:
+            pass
+     '''),
+    ('class_def_starred_and_kwarg',
+     '''
+        class C(A, B, *x, **y):
+            pass
+     '''),
+    ('class_def_starred_in_kwargs',
+     '''
+        class C(A, x=2, *[B, C], y=3):
+            pass
+     '''),
     ('comp', 'a == b'),
     ('comp_multiple', 'a == b == c'),
     ('decorator',


### PR DESCRIPTION
* Update docs
* Add one more test case, where a starred arg and a keyword arg appear together
* Delete posarg rule