### PR TITLE
Fix bug in comparison rule (#187)

### DIFF
--- a/data/simpy.gram
+++ b/data/simpy.gram
@@ -266,7 +266,7 @@ inversion[expr_ty]:
     | comparison
 comparison[expr_ty]:
     | a=bitwise_or b=compare_op_bitwise_or_pair+ {
-        Pegen_Compare(p, a, b) }
+        Pegen_Compare(p, a, b, EXTRA) }
     | bitwise_or
 compare_op_bitwise_or_pair[CmpopExprPair*]:
     | eq_bitwise_or
@@ -290,7 +290,7 @@ in_bitwise_or[CmpopExprPair*]: 'in' a=bitwise_or { cmpop_expr_pair(p, In, a) }
 isnot_bitwise_or[CmpopExprPair*]: 'is' 'not' a=bitwise_or { cmpop_expr_pair(p, IsNot, a) }
 is_bitwise_or[CmpopExprPair*]: 'is' a=bitwise_or { cmpop_expr_pair(p, Is, a) }
 
-bitwise_or[expr_ty]: 
+bitwise_or[expr_ty]:
     | a=bitwise_or '|' b=bitwise_xor { _Py_BinOp(a, BitOr, b, EXTRA) }
     | bitwise_xor
 bitwise_xor[expr_ty]:
@@ -349,7 +349,7 @@ slices[slice_ty]:
 slice[slice_ty]:
     | a=[expression] ':' b=[expression] c=[':' d=[expression] { d }] { _Py_Slice(a, b, c, p->arena) }
     | a=expression { _Py_Index(a, p->arena) }
-# STRING+'s output is just a hack for now 
+# STRING+'s output is just a hack for now
 atom[expr_ty]:
     | NAME
     | 'True' { _Py_Constant(Py_True, NULL, EXTRA) }

--- a/pegen/pegen.c
+++ b/pegen/pegen.c
@@ -890,10 +890,17 @@ _get_exprs(Parser *p, asdl_seq *seq)
 
 /* Wrapper for _Py_Compare, so that the call in the grammar stays concise */
 expr_ty
-Pegen_Compare(Parser *p, expr_ty expr, asdl_seq *pairs)
+Pegen_Compare(Parser *p,
+              expr_ty expr,
+              asdl_seq *pairs,
+              int lineno,
+              int col_offset,
+              int end_lineno,
+              int end_col_offset,
+              PyArena *arena)
 {
     return _Py_Compare(expr, _get_cmpops(p, pairs), _get_exprs(p, pairs),
-                       EXTRA_EXPR(expr, ((CmpopExprPair *)seq_get_tail(NULL, pairs))->expr));
+                       lineno, col_offset, end_lineno, end_col_offset, arena);
 }
 
 /* Creates an asdl_seq* where all the elements have been changed to have ctx as context */

--- a/pegen/pegen.h
+++ b/pegen/pegen.h
@@ -117,7 +117,7 @@ void *seq_get_head(void *, asdl_seq *);
 void *seq_get_tail(void *, asdl_seq *);
 asdl_seq *map_names_to_ids(Parser *, asdl_seq *);
 CmpopExprPair *cmpop_expr_pair(Parser *, cmpop_ty, expr_ty);
-expr_ty Pegen_Compare(Parser *, expr_ty, asdl_seq *);
+expr_ty Pegen_Compare(Parser *, expr_ty, asdl_seq *, int, int, int, int, PyArena *);
 expr_ty set_expr_context(Parser *, expr_ty, expr_context_ty);
 KeyValuePair *key_value_pair(Parser *, expr_ty, expr_ty);
 asdl_seq *get_keys(Parser *, asdl_seq *);

--- a/test/test_ast_generation.py
+++ b/test/test_ast_generation.py
@@ -84,6 +84,8 @@ TEST_CASES = [
     ('call_subscript', 'f()[0]'),
     ('comp', 'a == b'),
     ('comp_multiple', 'a == b == c'),
+    ('comp_paren_end', 'a == (b-1)'),
+    ('comp_paren_start', '(a-1) == b'),
     ('decorator',
      '''
         @a


### PR DESCRIPTION
Include leading or trailing parantheses in the line/col info of a Compare node