### PR TITLE
Fix segfault in debug mode when raising syntax errors (#204)

### DIFF
--- a/pegen/pegen.c
+++ b/pegen/pegen.c
@@ -69,7 +69,11 @@ raise_syntax_error(Parser *p, const char *errmsg, ...)
             goto error;
         }
     }
-    Py_ssize_t col_number = byte_offset_to_character_offset(loc, t->col_offset) + 1;
+    // We may receive tokens with the col_offset not initialized (-1) since
+    // emitted by fill_token(). For instance, this can happen in some error
+    // situations involving invalid indentation.
+    int col_offset = t->col_offset == -1 ? 0 : t->col_offset;
+    Py_ssize_t col_number = byte_offset_to_character_offset(loc, col_offset) + 1;
     tmp = Py_BuildValue("(OiiN)", filename, t->lineno, col_number, loc);
     if (!tmp) {
         goto error;

--- a/test/test_ast_generation.py
+++ b/test/test_ast_generation.py
@@ -523,6 +523,14 @@ FAIL_TEST_CASES = [
     ("f-string_lambda", "f'{lambda x: 42}'"),
     ("f-string_singe_brace", "f'{'"),
     ("f-string_single_closing_brace", "f'}'"),
+    # This test case checks error paths involving tokens with uninitialized
+    # values of col_offset and end_col_offset.
+    ("invalid indentation",
+     """
+     def f():
+         a
+             a
+     """),
 ]
 
 GOOD_BUT_FAIL_TEST_CASES = [


### PR DESCRIPTION
In some situations, we need to raise a syntax error with a token that
has an uninitialized value for col_offset (-1). This can happen with
invalid indentation errors. As we use that col_offset to get the source
for the traceback, we cannot use these uninitialized values in those cases.

Co-authored-by: Guido van Rossum <guido@python.org>