### PR TITLE
Propagate errors from helper functions (#130)

### DIFF
--- a/pegen/c_generator.py
+++ b/pegen/c_generator.py
@@ -479,6 +479,12 @@ class CParserGenerator(ParserGenerator, GrammarVisitor):
 
     def emit_action(self, node: Alt) -> None:
         self.print(f"res = {node.action};")
+
+        self.print("if (res == NULL && PyErr_Occurred()) {")
+        with self.indent():
+            self.print("longjmp(p->error_env, 1);")
+        self.print("}")
+
         if self.debug:
             self.print(
                 f'fprintf(stderr, "Hit with action [%d-%d]: %s\\n", mark, p->mark, "{node}");'

--- a/pegen/pegen.c
+++ b/pegen/pegen.c
@@ -36,13 +36,14 @@ byte_offset_to_character_offset(PyObject *line, int col_offset)
     return size;
 }
 
-static inline PyObject*
+static inline PyObject *
 get_error_line(char *buffer)
 {
     char *newline = strchr(buffer, '\n');
     if (newline) {
         return PyUnicode_FromStringAndSize(buffer, newline - buffer);
-    } else {
+    }
+    else {
         return PyUnicode_FromString(buffer);
     }
 }
@@ -69,7 +70,8 @@ raise_syntax_error(Parser *p, const char *errmsg, ...)
             Py_INCREF(Py_None);
             loc = Py_None;
         }
-    } else {
+    }
+    else {
         assert(p->input_mode == STRING_INPUT);
         loc = get_error_line(p->tok->buf);
         if (!loc) {
@@ -386,7 +388,6 @@ dedent_token(Parser *p)
     return expect_token(p, DEDENT);
 }
 
-
 static PyObject *
 parsenumber_raw(const char *s)
 {
@@ -401,7 +402,7 @@ parsenumber_raw(const char *s)
     end = s + strlen(s) - 1;
     imflag = *end == 'j' || *end == 'J';
     if (s[0] == '0') {
-        x = (long) PyOS_strtoul(s, (char **)&end, 0);
+        x = (long)PyOS_strtoul(s, (char **)&end, 0);
         if (x < 0 && errno == 0) {
             return PyLong_FromString(s, (char **)0, 0);
         }
@@ -421,16 +422,13 @@ parsenumber_raw(const char *s)
             return NULL;
         return PyComplex_FromCComplex(compl);
     }
-    else
-    {
+    else {
         dx = PyOS_string_to_double(s, NULL, NULL);
         if (dx == -1.0 && PyErr_Occurred())
             return NULL;
         return PyFloat_FromDouble(dx);
     }
 }
-
-
 
 static PyObject *
 parsenumber(const char *s)
@@ -460,8 +458,6 @@ parsenumber(const char *s)
     return res;
 }
 
-
-
 expr_ty
 number_token(Parser *p)
 {
@@ -470,7 +466,7 @@ number_token(Parser *p)
         return NULL;
     }
 
-    char* num_raw = PyBytes_AsString(t->bytes);
+    char *num_raw = PyBytes_AsString(t->bytes);
 
     if (num_raw == NULL) {
         return NULL;
@@ -492,8 +488,8 @@ number_token(Parser *p)
 }
 
 PyObject *
-run_parser(struct tok_state *tok, void *(start_rule_func)(Parser *), int mode,
-           int input_mode, KeywordToken **keywords, int n_keyword_lists)
+run_parser(struct tok_state *tok, void *(start_rule_func)(Parser *), int mode, int input_mode,
+           KeywordToken **keywords, int n_keyword_lists)
 {
     PyObject *result = NULL;
     Parser *p = PyMem_Malloc(sizeof(Parser));
@@ -530,7 +526,12 @@ run_parser(struct tok_state *tok, void *(start_rule_func)(Parser *), int mode,
 
     p->start_rule_func = start_rule_func;
 
+    int error = setjmp(p->error_env);
+    if (error) {
+        goto exit;
+    }
     void *res = (*start_rule_func)(p);
+
     if (res == NULL) {
         if (PyErr_Occurred()) {
             goto exit;
@@ -545,7 +546,7 @@ run_parser(struct tok_state *tok, void *(start_rule_func)(Parser *), int mode,
     }
 
     if (mode == 2) {
-        result = (PyObject *) PyAST_CompileObject(res, tok->filename, NULL, -1, p->arena);
+        result = (PyObject *)PyAST_CompileObject(res, tok->filename, NULL, -1, p->arena);
     }
     else if (mode == 1) {
         result = PyAST_mod2obj(res);
@@ -556,7 +557,6 @@ run_parser(struct tok_state *tok, void *(start_rule_func)(Parser *), int mode,
     }
 
 exit:
-
     for (int i = 0; i < p->size; i++) {
         PyMem_Free(p->tokens[i]);
     }
@@ -567,7 +567,6 @@ exit:
     PyMem_Free(p);
     return result;
 }
-
 
 PyObject *
 run_parser_from_file(const char *filename, void *(start_rule_func)(Parser *), int mode,
@@ -615,13 +614,14 @@ run_parser_from_string(const char *str, void *(start_rule_func)(Parser *), int m
     if (tok == NULL) {
         return NULL;
     }
+
     tok->filename = PyUnicode_FromString("<string>");
     if (tok->filename == NULL) {
-        goto exit;
+        PyTokenizer_Free(tok);
+        return NULL;
     }
+
     result = run_parser(tok, start_rule_func, mode, STRING_INPUT, keywords, n_keyword_lists);
-exit:
-    PyTokenizer_Free(tok);
     return result;
 }
 
@@ -877,17 +877,11 @@ _get_exprs(Parser *p, asdl_seq *seq)
 
 /* Wrapper for _Py_Compare, so that the call in the grammar stays concise */
 expr_ty
-Pegen_Compare(Parser *p,
-              expr_ty expr,
-              asdl_seq *pairs,
-              int lineno,
-              int col_offset,
-              int end_lineno,
-              int end_col_offset,
-              PyArena *arena)
+Pegen_Compare(Parser *p, expr_ty expr, asdl_seq *pairs, int lineno, int col_offset,
+              int end_lineno, int end_col_offset, PyArena *arena)
 {
-    return _Py_Compare(expr, _get_cmpops(p, pairs), _get_exprs(p, pairs),
-                       lineno, col_offset, end_lineno, end_col_offset, arena);
+    return _Py_Compare(expr, _get_cmpops(p, pairs), _get_exprs(p, pairs), lineno, col_offset,
+                       end_lineno, end_col_offset, arena);
 }
 
 /* Creates an asdl_seq* where all the elements have been changed to have ctx as context */
@@ -1297,22 +1291,18 @@ function_def_decorators(Parser *p, asdl_seq *decorators, stmt_ty function_def)
     if (function_def->kind == AsyncFunctionDef_kind) {
         return _Py_AsyncFunctionDef(
             function_def->v.FunctionDef.name, function_def->v.FunctionDef.args,
-            function_def->v.FunctionDef.body, decorators,
-            function_def->v.FunctionDef.returns,
+            function_def->v.FunctionDef.body, decorators, function_def->v.FunctionDef.returns,
             function_def->v.FunctionDef.type_comment, function_def->lineno,
-            function_def->col_offset, function_def->end_lineno,
-            function_def->end_col_offset, p->arena
-        );
+            function_def->col_offset, function_def->end_lineno, function_def->end_col_offset,
+            p->arena);
     }
 
-    return _Py_FunctionDef(
-        function_def->v.FunctionDef.name, function_def->v.FunctionDef.args,
-        function_def->v.FunctionDef.body, decorators,
-        function_def->v.FunctionDef.returns,
-        function_def->v.FunctionDef.type_comment, function_def->lineno,
-        function_def->col_offset, function_def->end_lineno,
-        function_def->end_col_offset, p->arena
-    );
+    return _Py_FunctionDef(function_def->v.FunctionDef.name, function_def->v.FunctionDef.args,
+                           function_def->v.FunctionDef.body, decorators,
+                           function_def->v.FunctionDef.returns,
+                           function_def->v.FunctionDef.type_comment, function_def->lineno,
+                           function_def->col_offset, function_def->end_lineno,
+                           function_def->end_col_offset, p->arena);
 }
 
 /* Construct a ClassDef equivalent to class_def, but with decorators */
@@ -1443,12 +1433,13 @@ concatenate_strings(Parser *p, asdl_seq *strings)
         if (fstr != NULL) {
             assert(s == NULL && !bytesmode);
 
-            int result = FstringParser_ConcatFstring(p, &state, &fstr, fstr+fstrlen,
+            int result = FstringParser_ConcatFstring(p, &state, &fstr, fstr + fstrlen,
                                                      this_rawmode, 0, first, t, last);
             if (result < 0) {
                 goto error;
             }
-        } else {
+        }
+        else {
             /* String or byte string. */
             assert(s != NULL && fstr == NULL);
             assert(bytesmode ? PyBytes_CheckExact(s) : PyUnicode_CheckExact(s));
@@ -1456,13 +1447,15 @@ concatenate_strings(Parser *p, asdl_seq *strings)
             if (bytesmode) {
                 if (i == 0) {
                     bytes_str = s;
-                } else {
+                }
+                else {
                     PyBytes_ConcatAndDel(&bytes_str, s);
                     if (!bytes_str) {
                         goto error;
                     }
                 }
-            } else {
+            }
+            else {
                 /* This is a regular string. Concatenate it. */
                 if (FstringParser_ConcatAndDel(&state, s) < 0) {
                     goto error;
@@ -1475,8 +1468,8 @@ concatenate_strings(Parser *p, asdl_seq *strings)
         if (PyArena_AddPyObject(p->arena, bytes_str) < 0) {
             goto error;
         }
-        return Constant(bytes_str, NULL, first->lineno, first->col_offset,
-                        last->end_lineno, last->end_col_offset, p->arena);
+        return Constant(bytes_str, NULL, first->lineno, first->col_offset, last->end_lineno,
+                        last->end_col_offset, p->arena);
     }
 
     return FstringParser_Finish(p, &state, first, last);

--- a/pegen/pegen.h
+++ b/pegen/pegen.h
@@ -6,6 +6,7 @@
 #include <token.h>
 #include <Python-ast.h>
 #include <pyarena.h>
+#include <setjmp.h>
 
 enum INPUT_MODE {
     FILE_INPUT,
@@ -43,6 +44,7 @@ typedef struct {
     int n_keyword_lists;
     void *start_rule_func;
     INPUT_MODE input_mode;
+    jmp_buf error_env;
 } Parser;
 
 typedef struct {

--- a/test/test_c_parser.py
+++ b/test/test_c_parser.py
@@ -344,3 +344,15 @@ def test_extension_name(tmp_path: PurePath) -> None:
 
     assert "PyInit_alternative_name" in parser_source
     assert '.m_name = "alternative_name"' in parser_source
+
+
+def test_error_in_rules(tmp_path: PurePath) -> None:
+    grammar_source = """
+    start: expr+ NEWLINE? ENDMARKER
+    expr: NAME {PyTuple_New(-1)}
+    """
+    grammar = parse_string(grammar_source, GrammarParser)
+    extension = generate_parser_c_extension(grammar, tmp_path)
+    # PyTuple_New raises SystemError if an invalid argument was passed.
+    with pytest.raises(SystemError):
+        extension.parse_string("a")


### PR DESCRIPTION
Make use of setjmp/longjmp to propagate errors from down the parser call stack to the
`run_parser` function where they can be processed correctly.