### PR TITLE
Insert absolute current directory into sys.path

### DIFF
--- a/scripts/test_parse_directory.py
+++ b/scripts/test_parse_directory.py
@@ -12,7 +12,7 @@ from pathlib import PurePath
 
 from typing import List, Optional, Any
 
-sys.path.insert(0, ".")
+sys.path.insert(0, os.getcwd())
 from pegen.build import build_parser_and_generator
 from pegen.testutil import print_memstats
 from scripts import show_parse


### PR DESCRIPTION
Using sys.path.insert(0, ".") started giving an error on
macOS Catalina (10.15.3) on "from pegen import parse":

    ImportError: dlopen(./pegen/parse.cpython-38-darwin.so, 2): no suitable image found.  Did find:
            file system relative paths not allowed in hardened programs

I'm not sure since when -- I think maybe since I installed Python
3.8.2 downloaded from python.org.